### PR TITLE
Changing regex for telephone number field to fix bug in component

### DIFF
--- a/runner/src/server/plugins/engine/components/TelephoneNumberField.ts
+++ b/runner/src/server/plugins/engine/components/TelephoneNumberField.ts
@@ -6,7 +6,7 @@ import { addClassOptionIfNone } from "./helpers";
 import { FormData, FormSubmissionErrors } from "../types";
 import joi, { Schema } from "joi";
 
-const PATTERN = /^[0-9\\\s+()-]*$/;
+const PATTERN = /^((\+\d{2})|(0)) ?\d{4} ?\d{6}$/;
 const DEFAULT_MESSAGE = "Enter a telephone number in the correct format";
 export class TelephoneNumberField extends FormComponent {
   constructor(def: TelephoneNumberFieldComponent, model: FormModel) {


### PR DESCRIPTION
# Description

Changed the regex in TelephoneNumberField component.
Previously characters allowed were
+ ( ) 0-9, but any amount of these.

Which caused issues of non-phone number values being entered.

New value allows for area codes, or 0 at the beginning. Then 10 characters after (with an optional space)
