### PR TITLE
OOC-4223 Update GDS govuk-frontend package in front end runner to 5.3.1 

### DIFF
--- a/designer/package.json
+++ b/designer/package.json
@@ -127,7 +127,7 @@
     "eslint-plugin-tsdoc": "^0.2.14",
     "file-loader": "^6.2.0",
     "flat": "5.0.2",
-    "govuk-frontend": "^4.0.1",
+    "govuk-frontend": "^4.8.0",
     "hoek": "^6.1.3",
     "html-webpack-plugin": "^4.5.2",
     "i18next-parser": "^3.3.0",

--- a/runner/config/default.js
+++ b/runner/config/default.js
@@ -71,11 +71,11 @@ module.exports = {
   // - COMMENT OUT TO TEST WITHOUT REDIS -
   // -----------------------------------------------------
 
-  // sessionCookiePassword: "${SessionCookies.Password}",
-  // redisHost: "${Redis.Host}",
-  // redisPort: 6379,
-  // redisPassword: "${Redis.Password}", // This should be set if you are deploying replicas - SET AS SECRET
-  // redisTls: true, //run in TLS mode
+  sessionCookiePassword: "${SessionCookies.Password}",
+  redisHost: "${Redis.Host}",
+  redisPort: 6379,
+  redisPassword: "${Redis.Password}", // This should be set if you are deploying replicas - SET AS SECRET
+  redisTls: true, //run in TLS mode
 
   // ------------------------------------------------------
   /**

--- a/runner/config/default.js
+++ b/runner/config/default.js
@@ -71,11 +71,11 @@ module.exports = {
   // - COMMENT OUT TO TEST WITHOUT REDIS -
   // -----------------------------------------------------
 
-  sessionCookiePassword: "${SessionCookies.Password}",
-  redisHost: "${Redis.Host}",
-  redisPort: 6379,
-  redisPassword: "${Redis.Password}", // This should be set if you are deploying replicas - SET AS SECRET
-  redisTls: true, //run in TLS mode
+  // sessionCookiePassword: "${SessionCookies.Password}",
+  // redisHost: "${Redis.Host}",
+  // redisPort: 6379,
+  // redisPassword: "${Redis.Password}", // This should be set if you are deploying replicas - SET AS SECRET
+  // redisTls: true, //run in TLS mode
 
   // ------------------------------------------------------
   /**

--- a/runner/package.json
+++ b/runner/package.json
@@ -61,7 +61,7 @@
     "config": "^3.3.7",
     "dotenv": "8.2.0",
     "expr-eval": "^2.0.2",
-    "govuk-frontend": "^4.3.1",
+    "govuk-frontend": "^5.3.1",
     "hapi-pino": "8.0.0",
     "hapi-pulse": "3.0.0",
     "hapi-rate-limit": "4.1.0",

--- a/runner/src/client/sass/_govuk.scss
+++ b/runner/src/client/sass/_govuk.scss
@@ -1,3 +1,3 @@
 $govuk-global-styles: true;
 
-@import "node_modules/govuk-frontend/govuk/all";
+@import "node_modules/govuk-frontend/dist/govuk/all";

--- a/runner/src/client/sass/_upload-dialog.scss
+++ b/runner/src/client/sass/_upload-dialog.scss
@@ -1,4 +1,4 @@
-@import "node_modules/govuk-frontend/govuk/helpers/colour";
+@import "node_modules/govuk-frontend/dist/govuk/helpers/colour";
 
 .upload-dialog {
   display: none;

--- a/runner/src/client/sass/modal-dialog.scss
+++ b/runner/src/client/sass/modal-dialog.scss
@@ -1,4 +1,4 @@
-@import "node_modules/govuk-frontend/govuk/all";
+@import "node_modules/govuk-frontend/dist/govuk/all";
 .modal-dialog {
   // Don't display modal if user doesn't have js. Can be overriden with .modal-dialog--no-js-persistent
   display: none;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4953,7 +4953,7 @@ __metadata:
     flagg: ^1.1.2
     flat: 5.0.2
     focus-trap-react: ^8.9.2
-    govuk-frontend: ^4.0.1
+    govuk-frontend: ^4.8.0
     hapi-pino: ^8.0.1
     hoek: ^6.1.3
     html-webpack-plugin: ^4.5.2
@@ -5131,7 +5131,7 @@ __metadata:
     expr-eval: ^2.0.2
     flat: 5.0.2
     form-data: ^4.0.0
-    govuk-frontend: ^4.3.1
+    govuk-frontend: ^5.3.1
     hapi-pino: 8.0.0
     hapi-pulse: 3.0.0
     hapi-rate-limit: 4.1.0
@@ -11362,10 +11362,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"govuk-frontend@npm:^4.3.1":
+"govuk-frontend@npm:^4.3.1, govuk-frontend@npm:^4.8.0":
   version: 4.8.0
   resolution: "govuk-frontend@npm:4.8.0"
   checksum: e255f924f399319e109347ec4993e0441fc5847a6a73ba44a465b1599c7d03e85c29212743b081ccd60e19224c6301143c77540b8e4bfe615fcb3e162b8663f4
+  languageName: node
+  linkType: hard
+
+"govuk-frontend@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "govuk-frontend@npm:5.3.1"
+  checksum: b87c2208a7b971cc6ac1d0c19eb188fe1f40587af6e904d60a18ed9e5e9fef2ad9cec53734b38ad512c4fbd6c947677845d0afeff4594c59f18905485b0d0ae9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

Upgrading govuk-frontend package to latest version 5.3.1. This will bring the webforms to latest GDS standards, including updating the styling of the phase banner Beta icon. 

<img width="513" alt="Screenshot 2024-05-01 at 10 11 47" src="https://github.com/ukhsa-collaboration/digital-form-builder/assets/30391244/15f2b72f-6f40-4523-a66b-7d4b2a0fded3">

Govuk-frontend has been upgraded in designer to 4.8.0 as error was seen in console relating to an asset, however upgrading to 5.3.1 is not needed for this ticket, requiring more fixes.

## Type of change

Package upgrade

# How Has This Been Tested?

Manually using the runner and designer locally to check it has updated visually. 

