### PR TITLE
OOC-4380 Fix service name on summary page

### DIFF
--- a/runner/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/runner/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -66,6 +66,7 @@ export class SummaryViewModel {
     request: HapiRequest
   ) {
     this.pageTitle = pageTitle;
+    this.name = model.name;
     const { relevantPages, endPage } = this.getRelevantPages(model, state);
     const details = this.summaryDetails(request, model, state, relevantPages);
     const { def } = model;


### PR DESCRIPTION
# Description

Updated service name in summary controller to ensure correct service name shows on summary page

Completes both tickets: 
https://jira.collab.test-and-trace.nhs.uk/browse/OOC-4380
https://jira.collab.test-and-trace.nhs.uk/browse/OOC-4381

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

Tested by developer running locally

# Checklist:

- [x] I have performed a self-review of my own code

