### PR TITLE
OOC-4405: Update landing page (part 2) content (CQC checkbox)

### DIFF
--- a/model/src/components/component-types.ts
+++ b/model/src/components/component-types.ts
@@ -11,6 +11,15 @@ export const ComponentTypes: ComponentDef[] = [
     schema: {},
   },
   {
+    name: "TextFieldCustom",
+    type: "TextFieldCustom",
+    title: "Text field",
+    subType: "field",
+    hint: "",
+    options: {},
+    schema: {},
+  },
+  {
     name: "MultilineTextField",
     type: "MultilineTextField",
     title: "Multiline text field",

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -184,6 +184,9 @@ export interface TextFieldCustomComponent extends TextFieldBase {
   type: "TextFieldCustom";
   options: TextFieldBase["options"] & {
     customValidationMessage?: string;
+    conditionalTextField?: {
+      dependsOn: string;
+    };
   };
 }
 

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -187,6 +187,7 @@ export interface TextFieldCustomComponent extends TextFieldBase {
     conditionalTextField?: {
       dependsOn: string;
     };
+    fieldName?: string;
   };
 }
 

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -1,5 +1,6 @@
 export enum ComponentTypeEnum {
   TextField = "TextField",
+  TextFieldCustom = "TextFieldCustom",
   MultilineTextField = "MultilineTextField",
   YesNoField = "YesNoField",
   DateField = "DateField",
@@ -28,6 +29,7 @@ export enum ComponentTypeEnum {
 
 export type ComponentType =
   | "TextField"
+  | "TextFieldCustom"
   | "MultilineTextField"
   | "YesNoField"
   | "DateField"
@@ -169,6 +171,13 @@ interface DateFieldBase {
 // Text Fields
 export interface TextFieldComponent extends TextFieldBase {
   type: "TextField";
+  options: TextFieldBase["options"] & {
+    customValidationMessage?: string;
+  };
+}
+
+export interface TextFieldCustomComponent extends TextFieldBase {
+  type: "TextFieldCustom";
   options: TextFieldBase["options"] & {
     customValidationMessage?: string;
   };
@@ -340,6 +349,7 @@ export type ComponentDef =
   | SelectFieldComponent
   | TelephoneNumberFieldComponent
   | TextFieldComponent
+  | TextFieldCustomComponent
   | TimeFieldComponent
   | UkAddressFieldComponent
   | YesNoFieldComponent

--- a/runner/src/server/forms/ReportAnOutbreak.json
+++ b/runner/src/server/forms/ReportAnOutbreak.json
@@ -33,7 +33,7 @@
       "title": "Acute Respiratory Infections (ARI) - COVID-19, Flu or unknown infection in Adult Social Care settings",
       "components": [
         {
-          "name": "S0Q4",
+          "name": "S0Q1",
           "options": {
             "customValidationMessages": {
               "string.regex.base": "Enter a full UK postcode",
@@ -41,48 +41,63 @@
             }
           },
           "type": "TextField",
-          "title": "Please enter your setting Postcode",
+          "title": "Your setting postcode",
           "schema": {
             "regex": "^([a-zA-Z]{1,2}[0-9][a-zA-Z0-9]? *[0-9][a-zA-Z]{2}|[a-zA-Z]{1,2}[0-9][a-zA-Z0-9]?)$"
           },
           "nameHasError": false,
-          "hint": "Please provide the postcode of the specific setting affected (i.e. not the overarching management company if applicable). If there is no one specific setting affected e.g. Domiciliary or Home Care, then please provide the postcode of the care provider company"
+          "hint": "Give the postcode of your care setting, not the management company. If you provide domiciliary or home care, enter the postcode of the care provider company."
         },
         {
           "name": "S0Q2",
+          "options": { "required": true },
+          "type": "SelectField",
+          "title": "Your local UKHSA health protection team",
+          "list": "sjgMDe",
+          "nameHasError": false,
+          "schema": {},
+          "values": {
+            "type": "listRef"
+          }
+        },
+        {
+          "name": "cstZQG",
+          "options": {},
+          "type": "Para",
+          "content": "<a target=\"_blank\" id=\"local-health-protection-team\" href=\"https://www.gov.uk/health-protection-team\">Use your postcode to find your local health protection team (opens in a new tab)</a>",
+          "schema": {}
+        },
+        {
+          "name": "S0Q3",
+          "options": { "required": false },
+          "type": "TextField",
+          "title": "Your Care Quality Commission (CQC) location ID",
+          "nameHasError": false,
+          "schema": {}
+        },
+        {
+          "name": "rIpMWq",
+          "options": {},
+          "type": "Para",
+          "content": "<div class='govuk-checkboxes__divider'>or</div>\n<script>\ndocument.addEventListener('DOMContentLoaded', function() {\nconst consultationLocation = document.getElementById('S0Q3');\nconst checkbox = document.getElementById('S0Q4');\nfunction updateTextFieldRequiredState() {\nconst isChecked = checkbox.checked;\nconsultationLocation.required = !isChecked;\n}\nfunction clearCheckbox() {\ncheckbox.checked = false;\n}\ncheckbox.addEventListener('change', function() {\nif (checkbox.checked) {\nconsultationLocation.value = '';\n}\nupdateTextFieldRequiredState();\n});\nconsultationLocation.addEventListener('input', function() {\nif (consultationLocation.value !== '') {\nclearCheckbox();\n}\nupdateTextFieldRequiredState()\n});\n});\n</script>"
+        },
+        {
+          "name": "S0Q4",
           "options": {
+            "hideTitle": true,
             "required": false
           },
-          "type": "TextField",
-          "title": "Please enter your CQC Location ID",
+          "type": "CheckboxesField",
+          "title": "  ",
           "nameHasError": false,
+          "list": "OZDejp",
           "schema": {}
         },
         {
           "name": "VMOkqi",
           "options": {},
           "type": "Para",
-          "content": "If you don’t know your CQC Location ID then please visit <a id=\"cqc number\" target=\"_blank\" href=\"https://www.cqc.org.uk/about-us/transparency/using-cqc-data\">Using CQC data - Care Quality Commission</a> and scroll about half way down the page to <b style=\"color:#1d70b8\">CQC care directory - csv</b>. You will find your CQC Location ID in this look up table.\n</br></br>",
-          "schema": {}
-        },
-        {
-          "name": "S0Q3",
-          "options": { "required": true },
-          "type": "SelectField",
-          "title": "Please enter your local HPT here",
-          "list": "sjgMDe",
-          "nameHasError": false,
-          "schema": {},
-          "values": {
-            "type": "listRef"
-          },
-          "hint": "Please make sure you've selected the correct local health protection team (HPT) to guarantee you receive the appropriate support"
-        },
-        {
-          "name": "cstZQG",
-          "options": {},
-          "type": "Para",
-          "content": "Click on the link to <a target=\"_blank\" id=\"local-health-protection-team\" href=\"https://www.gov.uk/health-protection-team\">Find your local health protection team in England - GOV.UK</a> (www.gov.uk) [Enter the postcode of your care setting]",
+          "content": "<a id=\"cqc number\" target=\"_blank\" href=\"https://www.cqc.org.uk/about-us/transparency/using-cqc-data\">Find your CQC location ID on the CQC website (opens in a new tab).</a> Find the care directory .csv file under the Data sheets heading.",
           "schema": {}
         }
       ],
@@ -1607,6 +1622,17 @@
     }
   ],
   "lists": [
+    {
+      "title": "cqc-location-unknown",
+      "name": "OZDejp",
+      "type": "string",
+      "items": [
+        {
+          "text": "My setting is not registered with the CQC",
+          "value": "My setting is not registered with the CQC"
+        }
+      ]
+    },
     {
       "title": "social-care-provider-type",
       "name": "MpSRIP",

--- a/runner/src/server/forms/ReportAnOutbreak.json
+++ b/runner/src/server/forms/ReportAnOutbreak.json
@@ -69,8 +69,8 @@
         },
         {
           "name": "S0Q3",
-          "options": { "required": false },
-          "type": "TextField",
+          "options": { "required": false, "optionalText": false },
+          "type": "TextFieldCustom",
           "title": "Your Care Quality Commission (CQC) location ID",
           "nameHasError": false,
           "schema": {}
@@ -79,7 +79,7 @@
           "name": "rIpMWq",
           "options": {},
           "type": "Para",
-          "content": "<div class='govuk-checkboxes__divider'>or</div>\n<script>\ndocument.addEventListener('DOMContentLoaded', function() {\nconst consultationLocation = document.getElementById('S0Q3');\nconst checkbox = document.getElementById('S0Q4');\nfunction updateTextFieldRequiredState() {\nconst isChecked = checkbox.checked;\nconsultationLocation.required = !isChecked;\n}\nfunction clearCheckbox() {\ncheckbox.checked = false;\n}\ncheckbox.addEventListener('change', function() {\nif (checkbox.checked) {\nconsultationLocation.value = '';\n}\nupdateTextFieldRequiredState();\n});\nconsultationLocation.addEventListener('input', function() {\nif (consultationLocation.value !== '') {\nclearCheckbox();\n}\nupdateTextFieldRequiredState()\n});\n});\n</script>"
+          "content": "<div class='govuk-checkboxes__divider'>or</div>"
         },
         {
           "name": "S0Q4",
@@ -97,8 +97,14 @@
           "name": "VMOkqi",
           "options": {},
           "type": "Para",
-          "content": "<a id=\"cqc number\" target=\"_blank\" href=\"https://www.cqc.org.uk/about-us/transparency/using-cqc-data\">Find your CQC location ID on the CQC website (opens in a new tab).</a> Find the care directory .csv file under the Data sheets heading.",
+          "content": "<a id=\"cqc number\" target=\"_blank\" href=\"https://www.cqc.org.uk/about-us/transparency/using-cqc-data\">Find your CQC location ID in the care directory on the CQC website (opens in a new tab).</a>",
           "schema": {}
+        },
+        {
+          "name": "rIpMWr",
+          "options": {},
+          "type": "Html",
+          "content": "<script>\ndocument.addEventListener('DOMContentLoaded', function() {\nconst cqcIdText = document.getElementById('S0Q3');\nconst cqcIdCheckbox = document.getElementById('S0Q4');\nfunction updateTextFieldRequiredState() {\nconst isChecked = cqcIdCheckbox.checked;\ncqcIdText.required = !isChecked;\n}\nfunction clearCheckbox() {\ncqcIdCheckbox.checked = false;\n}\ncqcIdCheckbox.addEventListener('change', function() {\nif (cqcIdCheckbox.checked) {\ncqcIdText.value = '';\n}\nupdateTextFieldRequiredState();\n});\ncqcIdText.addEventListener('input', function() {\nif (cqcIdText.value !== '') {\nclearCheckbox();\n}\nupdateTextFieldRequiredState()\n});\n});\n</script>"
         }
       ],
       "next": [

--- a/runner/src/server/forms/ReportAnOutbreak.json
+++ b/runner/src/server/forms/ReportAnOutbreak.json
@@ -88,7 +88,7 @@
             "required": false
           },
           "type": "CheckboxesField",
-          "title": "  ",
+          "title": "My setting is not registered with the CQC",
           "nameHasError": false,
           "list": "OZDejp",
           "schema": {}
@@ -1629,7 +1629,7 @@
   ],
   "lists": [
     {
-      "title": "cqc-location-unknown",
+      "title": "care-setting-not-registered",
       "name": "OZDejp",
       "type": "string",
       "items": [

--- a/runner/src/server/forms/ReportAnOutbreak.json
+++ b/runner/src/server/forms/ReportAnOutbreak.json
@@ -74,7 +74,8 @@
             "optionalText": false,
             "conditionalTextField": {
               "dependsOn": "S0Q4"
-            }
+            },
+            "fieldName": "cqc"
           },
           "type": "TextFieldCustom",
           "title": "Your Care Quality Commission (CQC) location ID",

--- a/runner/src/server/forms/ReportAnOutbreak.json
+++ b/runner/src/server/forms/ReportAnOutbreak.json
@@ -71,7 +71,10 @@
           "name": "S0Q3",
           "options": {
             "required": false,
-            "optionalText": false
+            "optionalText": false,
+            "conditionalTextField": {
+              "dependsOn": "S0Q4"
+            }
           },
           "type": "TextFieldCustom",
           "title": "Your Care Quality Commission (CQC) location ID",

--- a/runner/src/server/forms/ReportAnOutbreak.json
+++ b/runner/src/server/forms/ReportAnOutbreak.json
@@ -76,7 +76,9 @@
           "type": "TextFieldCustom",
           "title": "Your Care Quality Commission (CQC) location ID",
           "nameHasError": false,
-          "schema": {}
+          "schema": {
+            "regex": "^(1-\\d{1,9}|[a-zA-Z0-9]{3,7})$"
+          }
         },
         {
           "name": "rIpMWq",

--- a/runner/src/server/plugins/engine/components/CheckboxesField.ts
+++ b/runner/src/server/plugins/engine/components/CheckboxesField.ts
@@ -1,4 +1,9 @@
-import { FormData, FormSubmissionErrors, FormSubmissionState } from "../types";
+import {
+  FormData,
+  FormPayload,
+  FormSubmissionErrors,
+  FormSubmissionState,
+} from "../types";
 import { ListComponentsDef } from "@xgovformbuilder/model";
 import { FormModel } from "../models";
 import joi from "joi";
@@ -29,6 +34,10 @@ export class CheckboxesField extends SelectionControlField {
 
     this.formSchema = schema;
     this.stateSchema = schema;
+  }
+
+  getStateValueFromValidForm(payload: FormPayload) {
+    return payload[this.name];
   }
 
   getDisplayStringFromState(state: FormSubmissionState) {

--- a/runner/src/server/plugins/engine/components/TextFieldCustom.ts
+++ b/runner/src/server/plugins/engine/components/TextFieldCustom.ts
@@ -1,0 +1,42 @@
+import { TextFieldCustomComponent } from "@xgovformbuilder/model";
+import { FormModel } from "../models";
+import joi from "joi";
+import { TextField } from "./TextField";
+import * as helpers from "./helpers";
+import { FormPayload } from "../types";
+
+// Currently only used on the ReportAnOutbreak/uon-and-cqc page to handle textfield and checkbox comparisons
+export class TextFieldCustom extends TextField {
+  formSchema;
+  stateSchema;
+
+  constructor(def: TextFieldCustomComponent, model: FormModel) {
+    super(def, model);
+
+    const { options, schema = {} } = def;
+    this.options = options;
+    this.schema = schema;
+
+    let componentSchema = joi.optional().allow(null).allow("");
+    componentSchema = componentSchema.label(
+      def.title.en ?? def.title ?? def.name
+    );
+    this.formSchema = componentSchema;
+  }
+
+  getStateSchemaKeys() {
+    let schema: any = this.formSchema;
+    schema = schema.custom(helpers.customCqcValidator());
+
+    this.schema = schema;
+    return { [this.name]: schema };
+  }
+
+  getStateValueFromValidForm(payload: FormPayload) {
+    const cqcTextValue = payload["S0Q3"].trim();
+    if (cqcTextValue === "" && !payload["S0Q4"]) {
+      return false;
+    }
+    return cqcTextValue;
+  }
+}

--- a/runner/src/server/plugins/engine/components/TextFieldCustom.ts
+++ b/runner/src/server/plugins/engine/components/TextFieldCustom.ts
@@ -41,7 +41,7 @@ export class TextFieldCustom extends TextField {
     if (cqcTextValue === "" && !payload["S0Q4"]) {
       return false;
     }
-    if (!pattern.test(cqcTextValue)) {
+    if (cqcTextValue && !pattern.test(cqcTextValue)) {
       return "regex";
     }
     return cqcTextValue;

--- a/runner/src/server/plugins/engine/components/TextFieldCustom.ts
+++ b/runner/src/server/plugins/engine/components/TextFieldCustom.ts
@@ -11,6 +11,7 @@ export class TextFieldCustom extends FormComponent {
   stateSchema;
   pattern;
   dependentField;
+  fieldName;
 
   constructor(def: TextFieldCustomComponent, model: FormModel) {
     super(def, model);
@@ -27,6 +28,10 @@ export class TextFieldCustom extends FormComponent {
       this.dependentField = options.conditionalTextField.dependsOn;
     }
 
+    if (options.fieldName) {
+      this.fieldName = options.fieldName;
+    }
+
     let componentSchema = joi.optional().allow(null).allow("");
 
     this.formSchema = componentSchema;
@@ -34,7 +39,12 @@ export class TextFieldCustom extends FormComponent {
 
   getStateSchemaKeys() {
     let schema: any = this.formSchema;
-    schema = schema.custom(helpers.customCqcValidator());
+
+    if (this.fieldName) {
+      schema = schema.custom(
+        helpers.customTextCheckboxValidator(this.fieldName)
+      );
+    }
 
     this.schema = schema;
     return { [this.name]: schema };
@@ -47,7 +57,7 @@ export class TextFieldCustom extends FormComponent {
     if (currentFieldValue === "" && !dependentFieldValue) {
       return false;
     }
-    if (currentFieldValue && !this.pattern.test(dependentFieldValue)) {
+    if (currentFieldValue && !this.pattern.test(currentFieldValue)) {
       return "regex";
     }
     return currentFieldValue;

--- a/runner/src/server/plugins/engine/components/TextFieldCustom.ts
+++ b/runner/src/server/plugins/engine/components/TextFieldCustom.ts
@@ -9,7 +9,7 @@ import { FormPayload } from "../types";
 export class TextFieldCustom extends TextField {
   formSchema;
   stateSchema;
-  pattern = "^(1-\\d{1,9}|[a-zA-Z0-9]{3,7})$";
+  pattern;
 
   constructor(def: TextFieldCustomComponent, model: FormModel) {
     super(def, model);
@@ -17,6 +17,8 @@ export class TextFieldCustom extends TextField {
     const { options, schema = {} } = def;
     this.options = options;
     this.schema = schema;
+
+    this.pattern = schema.regex ? new RegExp(schema.regex) : null;
 
     let componentSchema = joi.optional().allow(null).allow("");
 
@@ -37,11 +39,10 @@ export class TextFieldCustom extends TextField {
 
   getStateValueFromValidForm(payload: FormPayload) {
     const cqcTextValue = payload["S0Q3"].trim();
-    const pattern = new RegExp(this.pattern);
     if (cqcTextValue === "" && !payload["S0Q4"]) {
       return false;
     }
-    if (cqcTextValue && !pattern.test(cqcTextValue)) {
+    if (cqcTextValue && !this.pattern.test(cqcTextValue)) {
       return "regex";
     }
     return cqcTextValue;

--- a/runner/src/server/plugins/engine/components/TextFieldCustom.ts
+++ b/runner/src/server/plugins/engine/components/TextFieldCustom.ts
@@ -41,15 +41,15 @@ export class TextFieldCustom extends FormComponent {
   }
 
   getStateValueFromValidForm(payload: FormPayload) {
-    const cqcTextValue = payload[this.name].trim();
-    const cqcCheckbox = payload[this.dependentField];
+    const currentFieldValue = payload[this.name].trim();
+    const dependentFieldValue = payload[this.dependentField];
 
-    if (cqcTextValue === "" && !cqcCheckbox) {
+    if (currentFieldValue === "" && !dependentFieldValue) {
       return false;
     }
-    if (cqcTextValue && !this.pattern.test(cqcTextValue)) {
+    if (currentFieldValue && !this.pattern.test(dependentFieldValue)) {
       return "regex";
     }
-    return cqcTextValue;
+    return currentFieldValue;
   }
 }

--- a/runner/src/server/plugins/engine/components/helpers.ts
+++ b/runner/src/server/plugins/engine/components/helpers.ts
@@ -149,15 +149,15 @@ export function getCustomDateValidator(
   };
 }
 
-export function customCqcValidator() {
+export function customTextCheckboxValidator(fieldName: string) {
   return (value: string, helpers: joi.CustomHelpers) => {
     if (!value) {
-      return helpers.error("string.cqc", {
+      return helpers.error(`string.${fieldName}`, {
         label: helpers.state.key,
       });
     }
     if (value == "regex") {
-      return helpers.error("string.cqc.regex", {
+      return helpers.error(`string.${fieldName}.regex`, {
         label: helpers.state.key,
       });
     }

--- a/runner/src/server/plugins/engine/components/helpers.ts
+++ b/runner/src/server/plugins/engine/components/helpers.ts
@@ -126,6 +126,17 @@ export function getCustomDateValidator(
   };
 }
 
+export function customCqcValidator() {
+  return (value: string, helpers: joi.CustomHelpers) => {
+    if (!value) {
+      return helpers.error("string.cqc", {
+        label: helpers.state.key,
+      });
+    }
+    return value;
+  };
+}
+
 export function internationalPhoneValidator(
   value: string,
   _helpers: joi.CustomHelpers

--- a/runner/src/server/plugins/engine/components/index.ts
+++ b/runner/src/server/plugins/engine/components/index.ts
@@ -28,6 +28,7 @@ export { RadiosField } from "./RadiosField";
 export { SelectField } from "./SelectField";
 export { TelephoneNumberField } from "./TelephoneNumberField";
 export { TextField } from "./TextField";
+export { TextFieldCustom } from "./TextFieldCustom";
 export { TimeField } from "./TimeField";
 export { UkAddressField } from "./UkAddressField";
 export { WebsiteField } from "./WebsiteField";

--- a/runner/src/server/plugins/engine/pageControllers/validationOptions.ts
+++ b/runner/src/server/plugins/engine/pageControllers/validationOptions.ts
@@ -22,6 +22,8 @@ const messageTemplate = {
   maxWords: "{{#label}} must be {{#limit}} words or fewer",
   dateRequired: "{{#label}} must be a real date",
   dateFormat: "{{#label}} must be a real date",
+  cqc:
+    "Enter your CQC location ID or select 'My setting is not registered with the CQC'",
 };
 
 export const messages: ValidationOptions["messages"] = {
@@ -32,6 +34,7 @@ export const messages: ValidationOptions["messages"] = {
   "string.email": messageTemplate.email,
   "string.regex.base": messageTemplate.format,
   "string.maxWords": messageTemplate.maxWords,
+  "string.cqc": messageTemplate.cqc,
 
   "date.base": messageTemplate.date,
   "date.empty": messageTemplate.required,

--- a/runner/src/server/plugins/engine/views/components/textfieldcustom.html
+++ b/runner/src/server/plugins/engine/views/components/textfieldcustom.html
@@ -1,0 +1,5 @@
+{% from "input/macro.njk" import govukInput %}
+
+{% macro TextFieldCustom(component) %}
+  {{ govukInput(component.model) }}
+{% endmacro %}

--- a/runner/src/server/plugins/engine/views/partials/form.html
+++ b/runner/src/server/plugins/engine/views/partials/form.html
@@ -1,7 +1,7 @@
 {% from "button/macro.njk" import govukButton %}
 {% from "summary-list/macro.njk" import govukSummaryList -%}
 
-<form method="post" enctype="multipart/form-data" autocomplete="on">
+<form method="post" enctype="multipart/form-data" autocomplete="on" novalidate>
   <input type="hidden" name="crumb" value="{{crumb}}"/>
   {{ componentList(components) }}
 


### PR DESCRIPTION
# Description

- Introduced checkbox option for CQC ID, so users can select it if care setting is not registered
- Rearranged question order
- New validation for checkbox and textfield
- Checkbox selection clears text field and vice versa
- Content updates
- Have had to add 'novalidate' to the form.html to override javascript validation messages that would appear on the field like the example below. This was overwriting the helpers.error message from being shown. Should not affect joi validation on other pages
![image](https://github.com/ukhsa-collaboration/digital-form-builder/assets/90158744/fde3c3e3-4bf2-43bb-9f05-a39c3c86f463)
- Have created TextFieldCustom (extension of TextField) component to cover this edge case of checkbox+textfield validation, as the custom helpers function would also handle all other text fields on the page. The custom text field ensures only a single text field is being handled by the component
- The error messages will behave weirdly though. When form is submitted with no values entered for any fields, only the normal text fields will show errors. Once they are filled, and cqc text+checkbox left empty, THEN the new error message will show. Not found a workaround for this unfortunately


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally ✅

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and versioning
- [ ] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
