### PR TITLE
OOC-4415/update error messages to defaults

### DIFF
--- a/runner/src/server/forms/ReportAnOutbreak.json
+++ b/runner/src/server/forms/ReportAnOutbreak.json
@@ -37,7 +37,9 @@
           "options": {
             "customValidationMessages": {
               "string.regex.base": "Enter a full UK postcode",
-              "string.pattern.base": "Enter a full UK postcode"
+              "string.pattern.base": "Enter a full UK postcode",
+              "string.empty": "Your setting postcode is required",
+              "string.base": "Your setting postcode is required"
             },
             "classes": "govuk-input--width-10"
           },
@@ -51,7 +53,13 @@
         },
         {
           "name": "S0Q3",
-          "options": { "required": true },
+          "options": {
+            "required": true,
+            "customValidationMessages": {
+              "string.empty": "Your local UKHSA health protection team is required",
+              "string.base": "Your local UKHSA health protection team is required"
+            }
+          },
           "type": "SelectField",
           "title": "Your local UKHSA health protection team",
           "list": "sjgMDe",
@@ -157,7 +165,11 @@
         {
           "name": "S1Q7",
           "options": {
-            "customValidationMessage": "Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192"
+            "customValidationMessage": "Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192", 
+            "customValidationMessages":{
+              "string.base":"S1Q7. Telephone number/s of Key Contact Person is required",
+              "string.empty":"S1Q7. Telephone number/s of Key Contact Person is required"
+            }
           },
           "type": "TelephoneNumberField",
           "title": "S1Q7. Telephone number/s of Key Contact Person",

--- a/runner/src/server/plugins/engine/pageControllers/validationOptions.ts
+++ b/runner/src/server/plugins/engine/pageControllers/validationOptions.ts
@@ -3,11 +3,8 @@ import { ValidationOptions } from "joi";
  * see @link https://joi.dev/api/?v=17.4.2#template-syntax for template syntax
  */
 const messageTemplate = {
-  /* The commented out values are the XGov Forms default messages*/
-  // required: "Enter {{#label}}",
-  // selectRequired: "Select {{#label}}",
-  required: "{{#label}} is required",
-  selectRequired: "{{#label}} is required",
+  required: "Enter {{#label}}",
+  selectRequired: "Select {{#label}}",
   max: "{{#label}} must be {{#limit}} characters or less",
   min: "{{#label}} must be {{#limit}} characters or more",
   regex: "enter a valid {{#label}}",


### PR DESCRIPTION
# Description

Given I am a care setting completing the Report an outbreak form
When I see error messages on the form 
Then I see that the error messages are in line with XGov form defaults
And I want the XGov form defaults to be excluded from the following error messages on Sections:

Landing page (part 2) - postcode, CQC ID & checkbox being omitted 
Section 1 - when no care setting is selected
Section 1 Continuation 1/2/3 - telephone number, email
Sections 4-6 - date error messages, numerical fields error messages
