### PR TITLE
CAR-326 Fix component schema error with respect to min and max numbers

### DIFF
--- a/runner/src/server/plugins/engine/components/NumberField.ts
+++ b/runner/src/server/plugins/engine/components/NumberField.ts
@@ -19,14 +19,11 @@ export class NumberField extends FormComponent {
 
     componentSchema = componentSchema.label(def.title.toLowerCase());
 
-    if (min && max) {
-      componentSchema = componentSchema.$;
-    }
-    if (min ?? false) {
+    if (min !== null && min !== undefined) {
       componentSchema = componentSchema.min(min);
     }
 
-    if (max ?? false) {
+    if (max !== null && max !== undefined) {
       componentSchema = componentSchema.max(max);
     }
 


### PR DESCRIPTION
This was a previous fix we put in on the live service, the logic for the schema for min and max on NumberField is weird so we changed it to this 