### PR TITLE
CAR-306 - Fix covid screening questions logic

### DIFF
--- a/runner/src/server/forms/ReportAnOutbreak.json
+++ b/runner/src/server/forms/ReportAnOutbreak.json
@@ -5018,7 +5018,7 @@
             }
           },
           {
-            "coordinator": "and",
+            "coordinator": "or",
             "field": {
               "name": "InfectionsYouAreReporting.TwoOrMoreCovidSpread",
               "type": "RadiosField",


### PR DESCRIPTION
Changing logic on Covid screening questions so that if No is answered on EITHER question then go to 'Do Not Report Screen' 