### PR TITLE
Fix - CAR-691 - Remove 'or on visits out' from staff question hints

### DIFF
--- a/runner/src/server/forms/ReportAnOutbreak.json
+++ b/runner/src/server/forms/ReportAnOutbreak.json
@@ -736,7 +736,7 @@
           "name": "StaffAdenovirus",
           "type": "NumberField",
           "title": "How many staff have tested positive for adenovirus?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital",
           "schema": {
             "min": 0,
             "max": 999
@@ -778,7 +778,7 @@
           "name": "StaffHmpv",
           "type": "NumberField",
           "title": "How many staff have tested positive for human Metapneumovirus (hMPV)?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital",
           "schema": {
             "min": 0,
             "max": 999
@@ -816,7 +816,7 @@
           "name": "StaffParainfluenza",
           "type": "NumberField",
           "title": "How many staff have tested positive for parainfluenza?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital",
           "schema": {
             "min": 0,
             "max": 999
@@ -850,7 +850,7 @@
           "name": "StaffRSV",
           "type": "NumberField",
           "title": "How many staff have tested positive for Respiratory Syncytial Virus (RSV)?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital",
           "schema": {
             "min": 0,
             "max": 999
@@ -880,7 +880,7 @@
           "name": "StaffRhinovirus",
           "type": "NumberField",
           "title": "How many staff have tested positive for rhinovirus?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital",
           "schema": {
             "min": 0,
             "max": 999
@@ -906,7 +906,7 @@
           "name": "StaffOtherARI",
           "type": "NumberField",
           "title": "How many staff have tested positive for an other acute respiratory infection?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital",
           "schema": {
             "min": 0,
             "max": 999
@@ -984,7 +984,7 @@
           "name": "StaffSymptomsNotTested",
           "type": "NumberField",
           "title": "How many staff have symptoms of an acute respiratory infection, but have not been tested for any infection?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital",
           "schema": {
             "min": 0,
             "max": 999
@@ -1032,7 +1032,7 @@
           "name": "StaffSymptomsNotTested",
           "type": "NumberField",
           "title": "How many staff have symptoms of an acute respiratory infection, but have not been tested for any infection?",
-          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0",
+          "hint": "Include those who are currently in hospital<br>If none, enter 0",
           "schema": {
             "min": 0,
             "max": 999
@@ -1637,7 +1637,7 @@
           "type": "NumberField",
           "name": "StaffCovidTestPositive",
           "title": "How many staff have COVID-19 confirmed by a positive test?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital",
           "options": {
             "required": true
           },
@@ -1649,7 +1649,7 @@
           "name": "StaffConfirmedARI",
           "type": "NumberField",
           "title": "How many staff have tested positive for adenovirus?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital",
           "schema": {},
           "options": {}
         },
@@ -1657,7 +1657,7 @@
           "name": "StaffSymptomsNotTested",
           "type": "NumberField",
           "title": "How many staff have symptoms of an acute respiratory infection, but have not been tested for any infection?",
-          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0",
+          "hint": "Include those who are currently in hospital<br>If none, enter 0",
           "schema": {},
           "options": {}
         },
@@ -1871,7 +1871,7 @@
           "type": "NumberField",
           "name": "StaffCovidTestPositive",
           "title": "How many staff have COVID-19 confirmed by a positive test?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital",
           "options": {
             "required": true
           },
@@ -1883,7 +1883,7 @@
           "type": "NumberField",
           "name": "StaffFluSwabTest",
           "title": "How many staff have flu confirmed by a positive swab test?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital",
           "schema": {}
         },
         {
@@ -1898,13 +1898,13 @@
           },
           "nameHasError": false,
           "title": "How many staff have been diagnosed with a chest infection by a GP?",
-          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0"
+          "hint": "Include those who are currently in hospital<br>If none, enter 0"
         },
         {
           "name": "StaffSymptomsNotTested",
           "type": "NumberField",
           "title": "How many staff have symptoms of an acute respiratory infection, but have not been tested for any infection?",
-          "hint": "Do not include cases that have been confirmed by a test as flu or diagnosed by a GP as a chest infection<br><br>Among elderly people this may include people who have a sudden onset of acute respiratory symptoms, fever, or sudden mental or physical deterioration without any other known cause<br><br>Include those who are currently in hospital or on visits out<br><br>If none, enter 0"
+          "hint": "Do not include cases that have been confirmed by a test as flu or diagnosed by a GP as a chest infection<br><br>Among elderly people this may include people who have a sudden onset of acute respiratory symptoms, fever, or sudden mental or physical deterioration without any other known cause<br><br>Include those who are currently in hospital<br><br>If none, enter 0"
         }
       ],
       "next": [
@@ -2189,7 +2189,7 @@
           "type": "NumberField",
           "name": "StaffCovidTestPositive",
           "title": "How many staff have COVID-19 confirmed by a positive test?",
-          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0",
+          "hint": "Include those who are currently in hospital<br>If none, enter 0",
           "options": {
             "required": true
           },
@@ -2201,7 +2201,7 @@
           "type": "NumberField",
           "name": "StaffSymptomsNotTested",
           "title": "How many staff have symptoms of an acute respiratory infection, but have not been tested for any infection?",
-          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0",
+          "hint": "Include those who are currently in hospital<br>If none, enter 0",
           "options": {
             "required": true
           },
@@ -2225,7 +2225,7 @@
           "type": "NumberField",
           "name": "StaffCovidTestPositive",
           "title": "How many staff have COVID-19 confirmed by a positive test?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital",
           "options": {
             "required": true
           },
@@ -2237,7 +2237,7 @@
           "type": "NumberField",
           "name": "StaffFluSwabTest",
           "title": "How many staff have flu confirmed by a positive swab test?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital",
           "schema": {},
           "options": {}
         },
@@ -2253,13 +2253,13 @@
           },
           "nameHasError": false,
           "title": "How many staff have been diagnosed with a chest infection by a GP?",
-          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0"
+          "hint": "Include those who are currently in hospital<br>If none, enter 0"
         },
         {
           "name": "StaffSymptomsNotTested",
           "title": "How many staff have symptoms of an acute respiratory infection, but have not been tested for any infection?",
           "type": "NumberField",
-          "hint": "Do not include cases that have been confirmed by a test as flu or diagnosed by a GP as a chest infection<br><br>Among elderly people this may include people who have a sudden onset of acute respiratory symptoms, fever, or sudden mental or physical deterioration without any other known cause<br><br>Include those who are currently in hospital or on visits out<br>If none, enter 0",
+          "hint": "Do not include cases that have been confirmed by a test as flu or diagnosed by a GP as a chest infection<br><br>Among elderly people this may include people who have a sudden onset of acute respiratory symptoms, fever, or sudden mental or physical deterioration without any other known cause<br><br>Include those who are currently in hospital<br>If none, enter 0",
           "schema": {},
           "options": {}
         }
@@ -2343,7 +2343,7 @@
           "type": "NumberField",
           "name": "StaffFluSwabTest",
           "title": "How many staff have flu confirmed by a positive swab test?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital",
           "schema": {},
           "options": {}
         },
@@ -2351,7 +2351,7 @@
           "name": "StaffConfirmedARI",
           "type": "NumberField",
           "title": "How many staff have tested positive for adenovirus?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital",
           "schema": {},
           "options": {}
         },
@@ -2367,13 +2367,13 @@
           },
           "nameHasError": false,
           "title": "How many staff have been diagnosed with a chest infection by a GP?",
-          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0"
+          "hint": "Include those who are currently in hospital<br>If none, enter 0"
         },
         {
           "name": "StaffSymptomsNotTested",
           "title": "How many staff have symptoms of an acute respiratory infection, but have not been tested for any infection?",
           "type": "NumberField",
-          "hint": "Do not include cases that have been confirmed by a test as flu or diagnosed by a GP as a chest infection<br><br>Among elderly people this may include people who have a sudden onset of acute respiratory symptoms, fever, or sudden mental or physical deterioration without any other known cause<br><br>Include those who are currently in hospital or on visits out<br>If none, enter 0",
+          "hint": "Do not include cases that have been confirmed by a test as flu or diagnosed by a GP as a chest infection<br><br>Among elderly people this may include people who have a sudden onset of acute respiratory symptoms, fever, or sudden mental or physical deterioration without any other known cause<br><br>Include those who are currently in hospital<br>If none, enter 0",
           "schema": {},
           "options": {}
         },


### PR DESCRIPTION
Question hints after: 

<img width="712" alt="Screenshot 2025-02-18 at 12 35 06" src="https://github.com/user-attachments/assets/804aadf5-8b6d-44fc-8b01-90a91c8f56ef" />
