### PR TITLE
Fix - CAR-725 - Consistent use of "If none, enter 0" in hint text

### DIFF
--- a/runner/src/server/forms/ReportAnOutbreak.json
+++ b/runner/src/server/forms/ReportAnOutbreak.json
@@ -1214,7 +1214,7 @@
           },
           "nameHasError": false,
           "title": "How many staff have flu confirmed by a positive swab test?",
-          "hint": "Include those who are currently in hospital."
+          "hint": "Include those who are currently in hospital<br>If none, enter 0"
         },
         {
           "name": "StaffChestInfection",

--- a/runner/src/server/forms/ReportAnOutbreak.json
+++ b/runner/src/server/forms/ReportAnOutbreak.json
@@ -540,7 +540,7 @@
           "name": "ServiceUsersAdenovirus",
           "type": "NumberField",
           "title": "How many service users have tested positive for adenovirus?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0",
           "schema": {
             "min": 0,
             "max": 999
@@ -582,7 +582,7 @@
           "name": "ServiceUsersHmpv",
           "type": "NumberField",
           "title": "How many service users have tested positive for human Metapneumovirus (hMPV)?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0",
           "schema": {
             "min": 0,
             "max": 999
@@ -620,7 +620,7 @@
           "name": "ServiceUsersParainfluenza",
           "type": "NumberField",
           "title": "How many service users have tested positive for parainfluenza?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0",
           "schema": {
             "min": 0,
             "max": 999
@@ -654,7 +654,7 @@
           "name": "ServiceUsersRSV",
           "type": "NumberField",
           "title": "How many service users have tested positive for Respiratory Syncytial Virus (RSV)?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0",
           "schema": {
             "min": 0,
             "max": 999
@@ -684,7 +684,7 @@
           "name": "ServiceUsersRhinovirus",
           "type": "NumberField",
           "title": "How many service users have tested positive for rhinovirus?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0",
           "schema": {
             "min": 0,
             "max": 999
@@ -710,7 +710,7 @@
           "name": "ServiceUsersOtherARI",
           "type": "NumberField",
           "title": "How many service users have tested positive for an other acute respiratory infection?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0",
           "schema": {
             "min": 0,
             "max": 999
@@ -736,7 +736,7 @@
           "name": "StaffAdenovirus",
           "type": "NumberField",
           "title": "How many staff have tested positive for adenovirus?",
-          "hint": "Include those who are currently in hospital",
+          "hint": "Include those who are currently in hospital<br>If none, enter 0",
           "schema": {
             "min": 0,
             "max": 999
@@ -778,7 +778,7 @@
           "name": "StaffHmpv",
           "type": "NumberField",
           "title": "How many staff have tested positive for human Metapneumovirus (hMPV)?",
-          "hint": "Include those who are currently in hospital",
+          "hint": "Include those who are currently in hospital<br>If none, enter 0",
           "schema": {
             "min": 0,
             "max": 999
@@ -816,7 +816,7 @@
           "name": "StaffParainfluenza",
           "type": "NumberField",
           "title": "How many staff have tested positive for parainfluenza?",
-          "hint": "Include those who are currently in hospital",
+          "hint": "Include those who are currently in hospital<br>If none, enter 0",
           "schema": {
             "min": 0,
             "max": 999
@@ -850,7 +850,7 @@
           "name": "StaffRSV",
           "type": "NumberField",
           "title": "How many staff have tested positive for Respiratory Syncytial Virus (RSV)?",
-          "hint": "Include those who are currently in hospital",
+          "hint": "Include those who are currently in hospital<br>If none, enter 0",
           "schema": {
             "min": 0,
             "max": 999
@@ -880,7 +880,7 @@
           "name": "StaffRhinovirus",
           "type": "NumberField",
           "title": "How many staff have tested positive for rhinovirus?",
-          "hint": "Include those who are currently in hospital",
+          "hint": "Include those who are currently in hospital<br>If none, enter 0",
           "schema": {
             "min": 0,
             "max": 999
@@ -906,7 +906,7 @@
           "name": "StaffOtherARI",
           "type": "NumberField",
           "title": "How many staff have tested positive for an other acute respiratory infection?",
-          "hint": "Include those who are currently in hospital",
+          "hint": "Include those who are currently in hospital<br>If none, enter 0",
           "schema": {
             "min": 0,
             "max": 999
@@ -928,7 +928,7 @@
           "name": "ServiceUsersConfirmedARI",
           "type": "NumberField",
           "title": "How many service users have symptoms of an acute respiratory infection but have not been tested?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0",
           "schema": {
             "min": 0,
             "max": 999
@@ -984,7 +984,7 @@
           "name": "StaffSymptomsNotTested",
           "type": "NumberField",
           "title": "How many staff have symptoms of an acute respiratory infection, but have not been tested for any infection?",
-          "hint": "Include those who are currently in hospital",
+          "hint": "Include those who are currently in hospital<br>If none, enter 0",
           "schema": {
             "min": 0,
             "max": 999
@@ -1141,7 +1141,7 @@
           },
           "nameHasError": false,
           "title": "How many service users have flu confirmed by a positive swab test?",
-          "hint": "Include those who are currently in hospital or on visits out"
+          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0"
         },
         {
           "name": "ServiceUsersChestInfection",
@@ -1580,7 +1580,7 @@
           "type": "NumberField",
           "name": "ServiceUsersCovidTestPositive",
           "title": "How many service users have COVID-19 confirmed by a positive test?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0",
           "options": {
             "required": true
           },
@@ -1592,7 +1592,7 @@
           "name": "ServiceUsersConfirmedARI",
           "type": "NumberField",
           "title": "How many service users have tested positive for adenovirus?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0",
           "schema": {},
           "options": {}
         },
@@ -1637,7 +1637,7 @@
           "type": "NumberField",
           "name": "StaffCovidTestPositive",
           "title": "How many staff have COVID-19 confirmed by a positive test?",
-          "hint": "Include those who are currently in hospital",
+          "hint": "Include those who are currently in hospital<br>If none, enter 0",
           "options": {
             "required": true
           },
@@ -1649,7 +1649,7 @@
           "name": "StaffConfirmedARI",
           "type": "NumberField",
           "title": "How many staff have tested positive for adenovirus?",
-          "hint": "Include those who are currently in hospital",
+          "hint": "Include those who are currently in hospital<br>If none, enter 0",
           "schema": {},
           "options": {}
         },
@@ -1769,7 +1769,7 @@
           "type": "NumberField",
           "name": "ServiceUsersCovidTestPositive",
           "title": "How many service users have COVID-19 confirmed by a positive test?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0",
           "options": {
             "required": true
           },
@@ -1781,7 +1781,7 @@
           "type": "NumberField",
           "name": "ServiceUsersFluSwabTest",
           "title": "How many service users have flu confirmed by a positive swab test?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0",
           "schema": {},
           "options": {}
         },
@@ -1871,7 +1871,7 @@
           "type": "NumberField",
           "name": "StaffCovidTestPositive",
           "title": "How many staff have COVID-19 confirmed by a positive test?",
-          "hint": "Include those who are currently in hospital",
+          "hint": "Include those who are currently in hospital<br>If none, enter 0",
           "options": {
             "required": true
           },
@@ -1883,7 +1883,7 @@
           "type": "NumberField",
           "name": "StaffFluSwabTest",
           "title": "How many staff have flu confirmed by a positive swab test?",
-          "hint": "Include those who are currently in hospital",
+          "hint": "Include those who are currently in hospital<br>If none, enter 0",
           "schema": {}
         },
         {
@@ -2127,7 +2127,7 @@
           "type": "NumberField",
           "name": "ServiceUsersCovidTestPositive",
           "title": "How many service users have COVID-19 confirmed by a positive test?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0",
           "options": {
             "required": true
           },
@@ -2139,7 +2139,7 @@
           "type": "NumberField",
           "name": "ServiceUsersFluSwabTest",
           "title": "How many service users have flu confirmed by a positive swab test?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0",
           "schema": {},
           "options": {}
         },
@@ -2225,7 +2225,7 @@
           "type": "NumberField",
           "name": "StaffCovidTestPositive",
           "title": "How many staff have COVID-19 confirmed by a positive test?",
-          "hint": "Include those who are currently in hospital",
+          "hint": "Include those who are currently in hospital<br>If none, enter 0",
           "options": {
             "required": true
           },
@@ -2237,7 +2237,7 @@
           "type": "NumberField",
           "name": "StaffFluSwabTest",
           "title": "How many staff have flu confirmed by a positive swab test?",
-          "hint": "Include those who are currently in hospital",
+          "hint": "Include those who are currently in hospital<br>If none, enter 0",
           "schema": {},
           "options": {}
         },
@@ -2279,7 +2279,7 @@
           "type": "NumberField",
           "name": "ServiceUsersFluSwabTest",
           "title": "How many service users have flu confirmed by a positive swab test?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0",
           "schema": {},
           "options": {}
         },
@@ -2287,7 +2287,7 @@
           "name": "ServiceUsersConfirmedARI",
           "type": "NumberField",
           "title": "How many service users have tested positive for adenovirus?",
-          "hint": "Include those who are currently in hospital or on visits out",
+          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0",
           "schema": {},
           "options": {}
         },
@@ -2343,7 +2343,7 @@
           "type": "NumberField",
           "name": "StaffFluSwabTest",
           "title": "How many staff have flu confirmed by a positive swab test?",
-          "hint": "Include those who are currently in hospital",
+          "hint": "Include those who are currently in hospital<br>If none, enter 0",
           "schema": {},
           "options": {}
         },
@@ -2351,7 +2351,7 @@
           "name": "StaffConfirmedARI",
           "type": "NumberField",
           "title": "How many staff have tested positive for adenovirus?",
-          "hint": "Include those who are currently in hospital",
+          "hint": "Include those who are currently in hospital<br>If none, enter 0",
           "schema": {},
           "options": {}
         },


### PR DESCRIPTION
<img width="712" alt="Screenshot 2025-02-18 at 13 06 42" src="https://github.com/user-attachments/assets/88c5b182-3215-4402-bb47-9c01955b00e6" />
