### PR TITLE
CAR-641 Add custom CSS for the beta phase tag

### DIFF
--- a/runner/src/client/sass/application.scss
+++ b/runner/src/client/sass/application.scss
@@ -109,3 +109,35 @@
 .govuk-checkboxes__conditional--hidden {
   display: none;
 }
+
+.govuk-phase-banner__content__tag {
+  background-color: #1d70b8; /* Example blue background */
+  padding: 5px 8px;
+  font-size: 1rem;
+  line-height: 1.25;
+  text-transform: lowercase;
+  letter-spacing: normal;
+}
+
+.govuk-phase-banner__content__tag::first-letter {
+  text-transform: uppercase;
+}
+
+.govuk-tag {
+  font-family: GDS Transport, arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.25;
+  display: inline-block;
+  max-width: 160px;
+  margin-top: -2px;
+  margin-bottom: -3px;
+  padding: 2px 8px 3px;
+  color: #0c2d4a;
+  background-color: #bbd4ea;
+  text-decoration: none;
+  overflow-wrap: break-word;
+  letter-spacing: 0;
+}


### PR DESCRIPTION
The CSS for the phase tags (alpha/beta) was updated as part of govuk-frontend v5.0.0 https://github.com/alphagov/govuk-frontend/releases/tag/v5.0.0-beta.0. 

Our designs include the new beta tag from v5, however an attempt to upgrade to the full latest govukfrontend package resulted in many styling changes which are not featured in our designs, and broke the conditionally revealed components. Upgrading to v5 would require a lot of changes to the base digital-forms-builder code. 

Therefore this change is just to add the CSS for the latest version of the phase tag. 

<img width="539" alt="Screenshot 2025-02-21 at 14 05 04" src="https://github.com/user-attachments/assets/f2ca7fbc-08c1-4dff-aa6f-85ff622b8b69" />
