### PR TITLE
CAR-512 Remove caption headings

### DIFF
--- a/runner/src/server/forms/ReportAnOutbreak.json
+++ b/runner/src/server/forms/ReportAnOutbreak.json
@@ -38,7 +38,6 @@
     {
       "path": "/setting",
       "title": "What type of adult social care do you provide?",
-      "section": "YourSetting",
       "sectionForExitJourneySummaryPages": "AcuteInfections",
       "sectionForMultiSummaryPages": "InfectionsInYourSetting",
       "components": [
@@ -75,7 +74,6 @@
     {
       "path": "/positive-ari",
       "title": "Do you have any positive test results for an acute respiratory infection?",
-      "section": "InfectionsYouAreReporting",
       "sectionForExitJourneySummaryPages": "AcuteInfections",
       "sectionForMultiSummaryPages": "InfectionsInYourSetting",
       "components": [
@@ -108,7 +106,6 @@
     {
       "path": "/which-ari",
       "title": "Which acute respiratory infections do you have a positive test result for?",
-      "section": "InfectionsYouAreReporting",
       "sectionForExitJourneySummaryPages": "AcuteInfections",
       "sectionForMultiSummaryPages": "InfectionsInYourSetting",
       "components": [
@@ -144,7 +141,6 @@
     {
       "path": "/2-or-more-covid",
       "title": "Are you reporting 2 or more cases?",
-      "section": "InfectionsYouAreReporting",
       "sectionForExitJourneySummaryPages": "AcuteInfections",
       "sectionForMultiSummaryPages": "Covid19InYourSetting",
       "components": [
@@ -179,7 +175,6 @@
     {
       "path": "/2-or-more-covid-descriptive",
       "title": "Are you reporting 2 or more cases of COVID-19?",
-      "section": "InfectionsYouAreReporting",
       "sectionForMultiSummaryPages": "Covid19InYourSetting",
       "components": [
         {
@@ -213,7 +208,6 @@
     {
       "path": "/2-or-more-covid-details",
       "title": "Acute respiratory infections in your setting",
-      "section": "InfectionsYouAreReporting",
       "sectionForExitJourneySummaryPages": "AcuteInfections",
       "sectionForMultiSummaryPages": "Covid19InYourSetting",
       "components": [
@@ -269,7 +263,6 @@
     {
       "path": "/2-or-more-ari",
       "title": "Are you reporting 2 or more cases of an acute respiratory infection?",
-      "section": "InfectionYouAreReporting",
       "sectionForExitJourneySummaryPages": "AcuteInfections",
       "sectionForMultiSummaryPages": "Covid19InYourSetting",
       "components": [
@@ -300,7 +293,6 @@
     {
       "path": "/do-not-need-to-report",
       "title": "You do not need to report",
-      "section": "InfectionsYouAreReporting",
       "controller": "CheckpointSummaryPageController",
       "options": {
         "customText": {
@@ -313,7 +305,6 @@
     {
       "path": "/do-not-need-to-report-multiple",
       "title": "You do not need to report",
-      "section": "InfectionsYouAreReporting",
       "controller": "CheckpointSummaryPageController",
       "options": {
         "multiSummary": true,
@@ -327,7 +318,6 @@
     {
       "path": "/2-or-more-cases-not-covid-or-flu",
       "title": "Are you reporting 2 or more cases of an acute respiratory infection that is not COVID-19 or flu?",
-      "section": "InfectionYouAreReporting",
       "sectionForExitJourneySummaryPages": "AcuteInfections",
       "sectionForMultiSummaryPages": "OtherInYourSetting",
       "components": [
@@ -375,7 +365,6 @@
     {
       "path": "/mid-way-summary",
       "title": "Check your answers before continuing",
-      "section": "InfectionsYouAreReporting",
       "controller": "CheckpointSummaryPageController",
       "options": {
         "multiSummary": true
@@ -385,7 +374,6 @@
     {
       "path": "/mid-way-summary-covid-yes-flu-yes-other-yes",
       "title": "Check your answers before continuing",
-      "section": "InfectionsYouAreReporting",
       "controller": "CheckpointSummaryPageController",
       "options": {
         "multiSummary": true
@@ -400,7 +388,6 @@
     {
       "path": "/mid-way-summary-covid-yes-other-no",
       "title": "Check your answers before continuing",
-      "section": "InfectionsYouAreReporting",
       "controller": "CheckpointSummaryPageController",
       "options": {
         "multiSummary": true,
@@ -413,7 +400,6 @@
     {
       "path": "/mid-way-summary-covid-no-other-yes",
       "title": "Check your answers before continuing",
-      "section": "InfectionsYouAreReporting",
       "controller": "CheckpointSummaryPageController",
       "options": {
         "multiSummary": true,
@@ -426,7 +412,6 @@
     {
       "path": "/ari-infection-type",
       "title": "What infection are you reporting?",
-      "section": "InfectionYouAreReporting",
       "sectionForMultiSummaryPages": "OtherInYourSetting",
       "components": [
         {
@@ -465,7 +450,6 @@
     {
       "path": "/service-users-ari-confirmed",
       "title": "Service users: number of cases",
-      "section": "InfectionsInYourSetting",
       "disableSingleComponentAsHeading": true,
       "components": [
         {
@@ -539,7 +523,6 @@
     {
       "path": "/service-users-ari-adenovirus",
       "title": "Service users: number of adenovirus cases",
-      "section": "InfectionsInYourSetting",
       "disableSingleComponentAsHeading": true,
       "components": [
         {
@@ -606,7 +589,6 @@
     {
       "path": "/staff-ari-adenovirus",
       "title": "Staff: number of adenovirus cases",
-      "section": "InfectionsInYourSetting",
       "disableSingleComponentAsHeading": true,
       "components": [
         {
@@ -669,7 +651,6 @@
     {
       "path": "/service-users-ari-hmpv",
       "title": "Service users: number of human Metapneumovirus (hMPV) cases",
-      "section": "InfectionsInYourSetting",
       "disableSingleComponentAsHeading": true,
       "components": [
         {
@@ -728,7 +709,6 @@
     {
       "path": "/staff-ari-hmpv",
       "title": "Staff: number of human Metapneumovirus (hMPV) cases",
-      "section": "InfectionsInYourSetting",
       "disableSingleComponentAsHeading": true,
       "components": [
         {
@@ -783,7 +763,6 @@
     {
       "path": "/service-users-ari-parainfluenza",
       "title": "Service users: number of parainfluenza cases",
-      "section": "InfectionsInYourSetting",
       "disableSingleComponentAsHeading": true,
       "components": [
         {
@@ -834,7 +813,6 @@
     {
       "path": "/staff-ari-parainfluenza",
       "title": "Staff: number of parainfluenza cases",
-      "section": "InfectionsInYourSetting",
       "disableSingleComponentAsHeading": true,
       "components": [
         {
@@ -881,7 +859,6 @@
     {
       "path": "/service-users-ari-rsv",
       "title": "Service users: number of Respiratory Syncytial Virus (RSV) cases",
-      "section": "InfectionsInYourSetting",
       "disableSingleComponentAsHeading": true,
       "components": [
         {
@@ -924,7 +901,6 @@
     {
       "path": "/staff-ari-rsv",
       "title": "Staff: number of Respiratory Syncytial Virus (RSV) cases",
-      "section": "InfectionsInYourSetting",
       "disableSingleComponentAsHeading": true,
       "components": [
         {
@@ -963,7 +939,6 @@
     {
       "path": "/service-users-ari-rhinovirus",
       "title": "Service users: number of rhinovirus cases",
-      "section": "InfectionsInYourSetting",
       "disableSingleComponentAsHeading": true,
       "components": [
         {
@@ -998,7 +973,6 @@
     {
       "path": "/staff-ari-rhinovirus",
       "title": "Staff: number of rhinovirus cases",
-      "section": "InfectionsInYourSetting",
       "disableSingleComponentAsHeading": true,
       "components": [
         {
@@ -1029,7 +1003,6 @@
     {
       "path": "/service-users-ari-other",
       "title": "Service users: number of other acute respiratory infection cases",
-      "section": "InfectionsInYourSetting",
       "disableSingleComponentAsHeading": true,
       "components": [
         {
@@ -1056,7 +1029,6 @@
     {
       "path": "/staff-ari-other",
       "title": "Staff: number of other acute respiratory infection cases",
-      "section": "InfectionsInYourSetting",
       "disableSingleComponentAsHeading": true,
       "components": [
         {
@@ -1079,7 +1051,6 @@
     {
       "path": "/service-users-ari-unknown",
       "title": "Service users: number of cases",
-      "section": "InfectionsInYourSetting",
       "disableSingleComponentAsHeading": true,
       "components": [
         {
@@ -1132,7 +1103,6 @@
     {
       "path": "/staff-ari-unknown",
       "title": "Staff: number of cases",
-      "section": "InfectionsInYourSetting",
       "disableSingleComponentAsHeading": true,
       "components": [
         {
@@ -1185,7 +1155,6 @@
     {
       "path": "/staff-ari-confirmed",
       "title": "Staff: number of cases",
-      "section": "InfectionsInYourSetting",
       "components": [
         {
           "name": "StaffSymptomsNotTested",
@@ -1281,7 +1250,6 @@
     {
       "path": "/cases-of-flu",
       "title": "How many cases are you reporting?",
-      "section": "InfectionsInYourSetting",
       "components": [
         {
           "name": "NumberOfCasesOfFlu",
@@ -1309,7 +1277,6 @@
     {
       "path": "/single-case-of-flu",
       "title": "Who has the case of flu?",
-      "section": "InfectionsInYourSetting",
       "components": [
         {
           "name": "SingleCaseOfFluServiceOrStaff",
@@ -1336,7 +1303,6 @@
     {
       "path": "/service-users-flu",
       "title": "Service users: number of cases",
-      "section": "InfectionsInYourSetting",
       "components": [
         {
           "name": "ServiceUsersFluSwabTest",
@@ -1404,7 +1370,6 @@
     {
       "path": "/staff-flu",
       "title": "Staff: number of cases",
-      "section": "InfectionsInYourSetting",
       "components": [
         {
           "type": "Para",
@@ -1461,7 +1426,6 @@
     {
       "path": "/symptom-onset-flu",
       "title": "Symptom onset for the case of flu",
-      "section": "FluInYourSetting",
       "components": [
         {
           "name": "intro",
@@ -1491,7 +1455,6 @@
     {
       "path": "/flu-severity",
       "title": "Severity of the case of flu",
-      "section": "FluInYourSetting",
       "components": [
         {
           "name": "SingleCaseOfFluSeverityCalledGP",
@@ -1536,7 +1499,6 @@
     {
       "path": "/vaccination",
       "title": "Vaccination among your service users and staff",
-      "section": "Vaccination",
       "components": [
         {
           "name": "ServiceUsersCovid19Vaccination",
@@ -1628,7 +1590,6 @@
     {
       "path": "/ari-unknown-cases-setting",
       "title": "Who has an acute respiratory infection?",
-      "section": "InfectionsInYourSetting",
       "components": [
         {
           "type": "Para",
@@ -1658,7 +1619,6 @@
     {
       "path": "/other-ari-confirmed-cases-setting",
       "title": "Who has an acute respiratory infection?",
-      "section": "InfectionsInYourSetting",
       "components": [
         {
           "type": "Para",
@@ -1688,7 +1648,6 @@
     {
       "path": "/ari-confirmed-cases-setting",
       "title": "Who has an acute respiratory infection?",
-      "section": "InfectionsInYourSetting",
       "components": [
         {
           "type": "Para",
@@ -1762,7 +1721,6 @@
     {
       "path": "/service-users-covid-ari",
       "title": "Service users: number of cases",
-      "section": "InfectionsInYourSetting",
       "components": [
         {
           "type": "NumberField",
@@ -1819,7 +1777,6 @@
     {
       "path": "/staff-covid-ari",
       "title": "Staff: number of cases",
-      "section": "InfectionsInYourSetting",
       "components": [
         {
           "type": "NumberField",
@@ -1872,7 +1829,6 @@
     {
       "path": "/staff-ari-cases",
       "title": "Staff: Number of cases",
-      "section": "Infections in your setting",
       "components": [
         {
           "type": "Para",
@@ -1951,7 +1907,6 @@
     {
       "path": "/service-users-master",
       "title": "Service users: number of cases",
-      "section": "InfectionsInYourSetting",
       "components": [
         {
           "type": "NumberField",
@@ -2050,7 +2005,6 @@
     {
       "path": "/staff-master",
       "title": "Staff: number of cases",
-      "section": "InfectionsInYourSetting",
       "components": [
         {
           "type": "NumberField",
@@ -2128,7 +2082,6 @@
     {
       "path": "/ipc",
       "title": "Infection prevention and control (IPC) and outbreak management in your setting",
-      "section": "InfectionPreventionAndControl",
       "components": [
         {
           "name": "IPCPractices",
@@ -2193,7 +2146,6 @@
     {
       "path": "/flu-severity-multiple-cases",
       "title": "Severity of illness in this outbreak",
-      "section": "SeverityOfIllness",
       "components": [
         {
           "type": "Para",
@@ -2266,7 +2218,6 @@
     {
       "path": "/service-users-covid",
       "title": "Service users: number of cases",
-      "section": "InfectionsInYourSetting",
       "components": [
         {
           "type": "NumberField",
@@ -2306,7 +2257,6 @@
     {
       "path": "/service-users-covid-flu",
       "title": "Service users: number of cases",
-      "section": "InfectionsInYourSetting",
       "components": [
         {
           "type": "NumberField",
@@ -2364,7 +2314,6 @@
     {
       "path": "/staff-covid",
       "title": "Staff: number of cases",
-      "section": "InfectionsInYourSetting",
       "components": [
         {
           "type": "Para",
@@ -2404,7 +2353,6 @@
     {
       "path": "/staff-covid-flu",
       "title": "Staff: number of cases",
-      "section": "InfectionsInYourSetting",
       "components": [
         {
           "type": "NumberField",
@@ -2458,7 +2406,6 @@
     {
       "path": "/service-users-flu-ari",
       "title": "Service users: number of cases",
-      "section": "InfectionsInYourSetting",
       "components": [
         {
           "type": "NumberField",
@@ -2522,7 +2469,6 @@
     {
       "path": "/staff-flu-ari",
       "title": "Staff: number of cases",
-      "section": "InfectionsInYourSetting",
       "components": [
         {
           "type": "NumberField",
@@ -2582,7 +2528,6 @@
     {
       "path": "/severity-of-illness",
       "title": "Severity of illness in this outbreak",
-      "section": "SeverityOfIllness",
       "components": [
         {
           "name": "severityIntro",
@@ -2627,7 +2572,6 @@
     {
       "path": "/symptom-onset",
       "title": "Symptom onset of cases in this outbreak",
-      "section": "SymptomStartDates",
       "components": [
         {
           "name": "introText1",
@@ -2671,7 +2615,6 @@
     {
       "path": "/agps",
       "title": "Do staff carrying out aerosol generating procedures (AGPs) wear fit-tested FFP3 masks?",
-      "section": "InfectionPreventionAndControl",
       "components": [
         {
           "name": "FFP3Masks",
@@ -2694,7 +2637,6 @@
     {
       "path": "/agency-staff",
       "title": "Do you use agency staff or share staff with other care settings?",
-      "section": "Staff",
       "components": [
         {
           "name": "AgencyStaff",
@@ -2721,7 +2663,6 @@
     {
       "path": "/additional-staff",
       "title": "How many additional agency staff or staff from other care settings have you used during this outbreak?",
-      "section": "Staff",
       "components": [
         {
           "name": "AdditionalStaff",
@@ -2744,7 +2685,6 @@
     {
       "path": "/setting-details",
       "title": "Setting details",
-      "section": "YourSetting",
       "components": [
         {
           "name": "SettingName",
@@ -2831,7 +2771,6 @@
     {
       "path": "/contact-details",
       "title": "Contact details",
-      "section": "YourSetting",
       "components": [
         {
           "name": "heading1",
@@ -2955,7 +2894,6 @@
     {
       "path": "/service-users",
       "title": "Service users and staff",
-      "section": "PeopleInYourSetting",
       "components": [
         {
           "name": "ServiceUsersTypes",
@@ -3452,60 +3390,8 @@
       "title": "Infection you are reporting"
     },
     {
-      "name": "InfectionsYouAreReporting",
-      "title": "Infections you are reporting"
-    },
-    {
       "name": "InfectionsInYourSetting",
       "title": "Infections in your setting"
-    },
-    {
-      "name": "SeverityOfIllness",
-      "title": "Severity of illness"
-    },
-    {
-      "name": "SymptomStartDates",
-      "title": "Symptom start dates"
-    },
-    {
-      "name": "Vaccination",
-      "title": "Vaccination"
-    },
-    {
-      "name": "Summary",
-      "title": "Summary"
-    },
-    {
-      "name": "SettingDetails",
-      "title": "Setting details"
-    },
-    {
-      "name": "PeopleInYourSetting",
-      "title": "People in your setting"
-    },
-    {
-      "name": "YourSetting",
-      "title": "Your setting"
-    },
-    {
-      "name": "FluAndChestInfectionInYourSetting",
-      "title": "Flu and chest infection in your setting"
-    },
-    {
-      "name": "InfectionPreventionAndControl",
-      "title": "Infection prevention and control"
-    },
-    {
-      "name": "Staff",
-      "title": "Staff"
-    },
-    {
-      "name": "ConfirmedOrUnknownARI",
-      "title": "Confirmed or unknown acute respiratory infection"
-    },
-    {
-      "name": "FluInYourSetting",
-      "title": "Flu in your setting"
     }
   ],
 
@@ -3518,7 +3404,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsInYourSetting.OtherARIServiceOrStaff",
+              "name": "OtherARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -3540,7 +3426,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsInYourSetting.OtherARIServiceOrStaff",
+              "name": "OtherARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -3562,7 +3448,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionYouAreReporting.ARIInfectionType",
+              "name": "ARIInfectionType",
               "type": "CheckboxesField",
               "display": "What infection are you reporting?"
             },
@@ -3576,7 +3462,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsInYourSetting.OtherARIServiceOrStaff",
+              "name": "OtherARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -3598,7 +3484,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionYouAreReporting.ARIInfectionType",
+              "name": "ARIInfectionType",
               "type": "CheckboxesField",
               "display": "What infection are you reporting?"
             },
@@ -3612,7 +3498,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsInYourSetting.OtherARIServiceOrStaff",
+              "name": "OtherARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -3634,7 +3520,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionYouAreReporting.ARIInfectionType",
+              "name": "ARIInfectionType",
               "type": "CheckboxesField",
               "display": "What infection are you reporting?"
             },
@@ -3648,7 +3534,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsInYourSetting.OtherARIServiceOrStaff",
+              "name": "OtherARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -3670,7 +3556,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionYouAreReporting.ARIInfectionType",
+              "name": "ARIInfectionType",
               "type": "CheckboxesField",
               "display": "What infection are you reporting?"
             },
@@ -3684,7 +3570,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsInYourSetting.OtherARIServiceOrStaff",
+              "name": "OtherARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -3706,7 +3592,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionYouAreReporting.ARIInfectionType",
+              "name": "ARIInfectionType",
               "type": "CheckboxesField",
               "display": "What infection are you reporting?"
             },
@@ -3720,7 +3606,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsInYourSetting.OtherARIServiceOrStaff",
+              "name": "OtherARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -3742,7 +3628,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionYouAreReporting.ARIInfectionType",
+              "name": "ARIInfectionType",
               "type": "CheckboxesField",
               "display": "What infection are you reporting?"
             },
@@ -3756,7 +3642,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsInYourSetting.OtherARIServiceOrStaff",
+              "name": "OtherARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -3778,7 +3664,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionYouAreReporting.ARIInfectionType",
+              "name": "ARIInfectionType",
               "type": "CheckboxesField",
               "display": "What infection are you reporting?"
             },
@@ -3792,7 +3678,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsInYourSetting.OtherARIServiceOrStaff",
+              "name": "OtherARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -3814,7 +3700,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionYouAreReporting.ARIInfectionType",
+              "name": "ARIInfectionType",
               "type": "CheckboxesField",
               "display": "What infection are you reporting?"
             },
@@ -3828,7 +3714,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsInYourSetting.OtherARIServiceOrStaff",
+              "name": "OtherARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -3850,7 +3736,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionYouAreReporting.ARIInfectionType",
+              "name": "ARIInfectionType",
               "type": "CheckboxesField",
               "display": "What infection are you reporting?"
             },
@@ -3864,7 +3750,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsInYourSetting.OtherARIServiceOrStaff",
+              "name": "OtherARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -3886,7 +3772,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionYouAreReporting.ARIInfectionType",
+              "name": "ARIInfectionType",
               "type": "CheckboxesField",
               "display": "What infection are you reporting?"
             },
@@ -3900,7 +3786,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsInYourSetting.OtherARIServiceOrStaff",
+              "name": "OtherARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -3922,7 +3808,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionYouAreReporting.ARIInfectionType",
+              "name": "ARIInfectionType",
               "type": "CheckboxesField",
               "display": "What infection are you reporting?"
             },
@@ -3936,7 +3822,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsInYourSetting.OtherARIServiceOrStaff",
+              "name": "OtherARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -3958,7 +3844,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionYouAreReporting.ARIInfectionType",
+              "name": "ARIInfectionType",
               "type": "CheckboxesField",
               "display": "What infection are you reporting?"
             },
@@ -3972,7 +3858,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsInYourSetting.OtherARIServiceOrStaff",
+              "name": "OtherARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -3994,7 +3880,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.PositiveARI",
+              "name": "PositiveARI",
               "type": "RadiosField",
               "display": "Do you have any positive test results for an acute respiratory infection?"
             },
@@ -4016,7 +3902,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionYouAreReporting.TwoOrMoreARI",
+              "name": "TwoOrMoreARI",
               "type": "RadiosField",
               "display": "Are you reporting 2 or more cases of an acute respiratory infection?"
             },
@@ -4038,7 +3924,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.TwoOrMoreCovid",
+              "name": "TwoOrMoreCovid",
               "type": "RadiosField",
               "display": "Are you reporting 2 or more cases?"
             },
@@ -4060,7 +3946,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4082,7 +3968,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4096,7 +3982,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4110,7 +3996,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4132,7 +4018,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4146,7 +4032,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4168,7 +4054,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4182,7 +4068,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4204,7 +4090,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4218,7 +4104,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4232,7 +4118,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionYouAreReporting.TwoOrMoreCasesNotCovidFlu",
+              "name": "TwoOrMoreCasesNotCovidFlu",
               "type": "RadiosField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4246,7 +4132,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionYouAreReporting.TwoOrMoreCasesNotCovidFlu",
+              "name": "TwoOrMoreCasesNotCovidFlu",
               "type": "RadiosField",
               "display": "Are you reporting 2 or more cases of an acute respiratory infection that is not COVID-19 or flu?"
             },
@@ -4268,7 +4154,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4282,7 +4168,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4296,7 +4182,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsYouAreReporting.TwoOrMoreCovid",
+              "name": "TwoOrMoreCovid",
               "type": "RadiosField",
               "display": "Are you reporting 2 or more cases of COVID-19?"
             },
@@ -4310,7 +4196,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionYouAreReporting.TwoOrMoreARI",
+              "name": "TwoOrMoreARI",
               "type": "RadiosField",
               "display": "Are you reporting 2 or more cases of an acute respiratory infection?"
             },
@@ -4332,7 +4218,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4346,7 +4232,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4360,7 +4246,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsYouAreReporting.TwoOrMoreCovid",
+              "name": "TwoOrMoreCovid",
               "type": "RadiosField",
               "display": "Are you reporting 2 or more cases of COVID-19?"
             },
@@ -4374,7 +4260,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionYouAreReporting.TwoOrMoreCasesNotCovidFlu",
+              "name": "TwoOrMoreCasesNotCovidFlu",
               "type": "RadiosField",
               "display": "Are you reporting 2 or more cases of an acute respiratory infection that is not COVID-19 or flu?"
             },
@@ -4396,7 +4282,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4410,7 +4296,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4424,7 +4310,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsYouAreReporting.TwoOrMoreCovid5days",
+              "name": "TwoOrMoreCovid5days",
               "type": "RadiosField",
               "display": "Did symptoms in 2 or more cases of COVID-19 start within 5 days of each other?"
             },
@@ -4438,7 +4324,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsYouAreReporting.TwoOrMoreCovidSpread",
+              "name": "TwoOrMoreCovidSpread",
               "type": "RadiosField",
               "display": "Is it possible that at least 2 of the cases of COVID-19 are linked by spread in your setting?​"
             },
@@ -4452,7 +4338,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionYouAreReporting.TwoOrMoreCasesNotCovidFlu",
+              "name": "TwoOrMoreCasesNotCovidFlu",
               "type": "RadiosField",
               "display": "Are you reporting 2 or more cases of an acute respiratory infection that is not COVID-19 or flu?"
             },
@@ -4475,7 +4361,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4497,7 +4383,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4519,7 +4405,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4533,7 +4419,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4555,7 +4441,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4569,7 +4455,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4591,7 +4477,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4605,7 +4491,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4619,7 +4505,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4641,7 +4527,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4655,7 +4541,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4669,7 +4555,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4683,7 +4569,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsInYourSetting.ARIServiceOrStaff",
+              "name": "ARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -4705,7 +4591,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4719,7 +4605,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4733,7 +4619,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4747,7 +4633,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsInYourSetting.ARIServiceOrStaff",
+              "name": "ARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -4769,7 +4655,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4783,7 +4669,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4797,7 +4683,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsInYourSetting.ARIServiceOrStaff",
+              "name": "ARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -4819,7 +4705,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4833,7 +4719,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4847,7 +4733,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsInYourSetting.ARIServiceOrStaff",
+              "name": "ARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -4869,7 +4755,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4883,7 +4769,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4897,7 +4783,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsInYourSetting.ARIServiceOrStaff",
+              "name": "ARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -4919,7 +4805,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4933,7 +4819,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4947,7 +4833,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsInYourSetting.ARIServiceOrStaff",
+              "name": "ARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -4969,7 +4855,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -4983,7 +4869,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsInYourSetting.ARIServiceOrStaff",
+              "name": "ARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -5005,7 +4891,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -5019,7 +4905,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsInYourSetting.ARIServiceOrStaff",
+              "name": "ARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -5041,7 +4927,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -5055,7 +4941,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -5069,7 +4955,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsInYourSetting.ARIServiceOrStaff",
+              "name": "ARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -5091,7 +4977,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -5105,7 +4991,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -5119,7 +5005,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsInYourSetting.ARIServiceOrStaff",
+              "name": "ARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -5141,7 +5027,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -5155,7 +5041,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsInYourSetting.ARIServiceOrStaff",
+              "name": "ARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -5177,7 +5063,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.WhichARI",
+              "name": "WhichARI",
               "type": "CheckboxesField",
               "display": "Which acute respiratory infections do you have a positive test result for?"
             },
@@ -5191,7 +5077,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsInYourSetting.ARIServiceOrStaff",
+              "name": "ARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -5213,7 +5099,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.TwoOrMoreCovid5days",
+              "name": "TwoOrMoreCovid5days",
               "type": "RadiosField",
               "display": "Did symptoms in 2 or more cases of COVID-19 start within 5 days of each other?"
             },
@@ -5235,7 +5121,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsYouAreReporting.TwoOrMoreCovid5days",
+              "name": "TwoOrMoreCovid5days",
               "type": "RadiosField",
               "display": "Did symptoms in 2 or more cases of COVID-19 start within 5 days of each other?"
             },
@@ -5249,7 +5135,7 @@
           {
             "coordinator": "or",
             "field": {
-              "name": "InfectionsYouAreReporting.TwoOrMoreCovidSpread",
+              "name": "TwoOrMoreCovidSpread",
               "type": "RadiosField",
               "display": "Is it possible that at least 2 of the cases of COVID-19 are linked by spread in your setting?​"
             },
@@ -5271,7 +5157,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionYouAreReporting.TwoOrMoreCasesNotCovidFlu",
+              "name": "TwoOrMoreCasesNotCovidFlu",
               "type": "RadiosField",
               "display": "Are you reporting 2 or more cases of an acute respiratory infection that is not COVID-19 or flu?"
             },
@@ -5293,7 +5179,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsInYourSetting.SingleCaseOfFluServiceOrStaff",
+              "name": "SingleCaseOfFluServiceOrStaff",
               "type": "RadiosField",
               "display": "Who has the case of flu?"
             },
@@ -5315,7 +5201,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsInYourSetting.NumberOfCasesOfFlu",
+              "name": "NumberOfCasesOfFlu",
               "type": "RadiosField",
               "display": "How many cases of flu are you reporting?"
             },
@@ -5337,7 +5223,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsInYourSetting.CovidServiceOrStaff",
+              "name": "CovidServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of COVID-19 in?"
             },
@@ -5359,7 +5245,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsInYourSetting.CovidServiceOrStaff",
+              "name": "CovidServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of COVID-19 in?"
             },
@@ -5381,7 +5267,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsInYourSetting.CovidServiceOrStaff",
+              "name": "CovidServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of COVID-19 in?"
             },
@@ -5395,7 +5281,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsInYourSetting.CovidServiceOrStaff",
+              "name": "CovidServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of COVID-19 in?"
             },
@@ -5417,7 +5303,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsInYourSetting.ARIServiceOrStaff",
+              "name": "ARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -5439,7 +5325,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsInYourSetting.ARIServiceOrStaff",
+              "name": "ARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -5461,7 +5347,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionsInYourSetting.ARIServiceOrStaff",
+              "name": "ARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -5475,7 +5361,7 @@
           {
             "coordinator": "and",
             "field": {
-              "name": "InfectionsInYourSetting.ARIServiceOrStaff",
+              "name": "ARIServiceOrStaff",
               "type": "CheckboxesField",
               "display": "Who are you reporting cases or symptoms of an acute respiratory infection in?"
             },
@@ -5497,7 +5383,7 @@
         "conditions": [
           {
             "field": {
-              "name": "InfectionPreventionAndControl.AGPs",
+              "name": "AGPs",
               "type": "RadiosField",
               "display": "Does your setting undertake aerosol generating procedures (AGPs)?"
             },
@@ -5519,7 +5405,7 @@
         "conditions": [
           {
             "field": {
-              "name": "Staff.AgencyStaff",
+              "name": "AgencyStaff",
               "type": "RadiosField",
               "display": "Do you use agency staff or share staff with other care settings?"
             },


### PR DESCRIPTION
Accessibility testing has raised an issue with headings not being in the correct order, and future designs do not include caption headings therefore these are being removed. 

This necessitates altering the logic in the conditions as these require the section names if available to identify the question. Removing these. 