### PR TITLE
Security Bug: Update TestEndpointConfig.json

### DIFF
--- a/runner/src/server/forms/TestEndpointConfig.json
+++ b/runner/src/server/forms/TestEndpointConfig.json
@@ -94,7 +94,7 @@
       "title": "SRS Endpoint",
       "type": "webhook",
       "outputConfiguration": {
-        "url": "https://060nw3t077.execute-api.eu-west-2.amazonaws.com/v1/forms",
+        "url": "",
         "allowRetry": true,
         "sendAdditionalPayMetadata": false
       }


### PR DESCRIPTION
1) The URL **_SHOULD NOT_** be exposed directly to the web (env var/config etc).
2) I was able to hit this with at least 3500 requests within 33 seconds, there seems to be no rate-limiting (at least none that I have hit).

This could start to become EXTREMELY expensive if an attacker decides to send heavy payloads/a lot more requests.

![image](https://github.com/user-attachments/assets/6f0cba6e-8bdf-451f-8c9c-b3bfd0d8c35b)
