### PR TITLE
CAR-1369 Set cookies securely by default when using HTTPS

### DIFF
--- a/designer/server/config.ts
+++ b/designer/server/config.ts
@@ -22,6 +22,7 @@ export interface Config {
   lastTag: string;
   sessionTimeout: number;
   sessionCookiePassword: string;
+  httpsCookieSecureAttribute: boolean;
   awsCredentials?: CredentialsOptions;
 }
 
@@ -49,6 +50,7 @@ const schema = joi.object({
   lastTag: joi.string().default("undefined"),
   sessionTimeout: joi.number().default(sessionSTimeoutInMilliseconds),
   sessionCookiePassword: joi.string().optional(),
+  httpsCookieSecureAttribute: joi.boolean().optional(),
 });
 
 // Build config
@@ -66,6 +68,7 @@ const config = {
   lastTag: process.env.LAST_TAG || process.env.LAST_TAG_GH,
   sessionTimeout: process.env.SESSION_TIMEOUT,
   sessionCookiePassword: process.env.SESSION_COOKIE_PASSWORD,
+  httpsCookieSecureAttribute: process.env.HTTPS_COOKIE_SECURE_ATTRIBUTE,
 };
 
 // Validate config

--- a/designer/server/plugins/session.ts
+++ b/designer/server/plugins/session.ts
@@ -16,7 +16,7 @@ export const configureYarPlugin = (): ServerRegisterPluginObject<yar> => {
             .fill(0)
             .map(() => Math.random().toString(36).charAt(2))
             .join(""),
-        isSecure: config.isProd,
+        isSecure: config.httpsCookieSecureAttribute,
         isHttpOnly: true,
         isSameSite: "Lax",
       },

--- a/runner/config/custom-environment-variables.json
+++ b/runner/config/custom-environment-variables.json
@@ -27,6 +27,7 @@
   "sessionTimeout": "SESSION_TIMEOUT",
   "confirmationSessionTimeout": "CONFIRMATION_SESSION_TIMEOUT",
   "sessionCookiePassword": "SESSION_COOKIE_PASSWORD",
+  "sessionCookieSecureAttribute": "SESSION_COOKIE_SECURE_ATTRIBUTE",
   "fromEmailAddress": "FROM_EMAIL_ADDRESS",
   "serviceStartPage": "SERVICE_START_PAGE",
   "privacyPolicyUrl": "PRIVACY_POLICY_URL",

--- a/runner/config/default.js
+++ b/runner/config/default.js
@@ -68,6 +68,7 @@ module.exports = {
   sessionTimeout: 20 * minute,
   confirmationSessionTimeout: 20 * minute,
   paymentSessionTimeout: 90 * minute, // GOV.UK Pay sessions are 90 minutes. It is possible a user takes longer than 20 minutes to complete a payment.
+  httpsCookieSecureAttribute: true, // Assumed usage of HTTPS. Set to false if you are using HTTP.
   sessionCookiePassword: "${SessionCookies.Password}",
   redisHost: "${Redis.Host}",
   redisPort: 6379,

--- a/runner/config/development.json
+++ b/runner/config/development.json
@@ -2,5 +2,6 @@
   "isTest": true,
   "previewMode": true,
   "enforceCsrf": false,
+  "httpsCookieSecureAttribute": true,
   "env": "development"
 }

--- a/runner/config/production.json
+++ b/runner/config/production.json
@@ -2,5 +2,6 @@
   "env": "production",
   "logPrettyPrint": false,
   "enforceCsrf": true,
+  "httpsCookieSecureAttribute": true,
   "previewMode": false
 }

--- a/runner/config/test.json
+++ b/runner/config/test.json
@@ -7,6 +7,7 @@
   "isTest": true,
   "previewMode": true,
   "enforceCsrf": true,
+  "httpsCookieSecureAttribute": true,
   "initialisedSessionKey": "predictable-key",
   "env": "test",
   "documentUploadApiUrl": "http://localhost:9000"

--- a/runner/src/server/plugins/crumb.ts
+++ b/runner/src/server/plugins/crumb.ts
@@ -13,7 +13,7 @@ export const configureCrumbPlugin = (
       enforce: routeConfig?.enforceCsrf ?? config?.enforceCsrf,
       cookieOptions: {
         path: "/",
-        isSecure: !config.isDev,
+        isSecure: config.httpsCookieSecureAttribute,
         isHttpOnly: true,
         isSameSite: "Strict",
       },

--- a/runner/src/server/plugins/session.ts
+++ b/runner/src/server/plugins/session.ts
@@ -9,7 +9,7 @@ export default {
     },
     cookieOptions: {
       password: config.sessionCookiePassword || generateCookiePassword(),
-      isSecure: !config.isDev,
+      isSecure: config.httpsCookieSecureAttribute,
       isHttpOnly: true,
       isSameSite: "Lax",
     },

--- a/runner/src/server/utils/configSchema.ts
+++ b/runner/src/server/utils/configSchema.ts
@@ -54,6 +54,7 @@ export const configSchema = Joi.object({
   sslCert: Joi.string().optional(),
   sessionTimeout: Joi.number(),
   sessionCookiePassword: Joi.string().optional(),
+  httpsCookieSecureAttribute: Joi.boolean().optional(),
   rateLimit: Joi.boolean().optional(),
   fromEmailAddress: Joi.string().optional().allow(""),
   serviceStartPage: Joi.string().optional().allow(""),


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Please also include any acceptance criteria if you have any.

- Change cookies to be set 'Secure' for use with HTTPS by default regardless of environment value.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce
the testing if necessary.

- [x] Manually verified within network inspector

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and versioning
- [ ] I have updated the architecture diagrams as per Contribute.md OR added an architectural decision record entry
