### PR TITLE
feat: analytics support for form-level tracking

### DIFF
--- a/model/src/data-model/types.ts
+++ b/model/src/data-model/types.ts
@@ -188,6 +188,13 @@ export type ExitOptions = {
   format?: "STATE" | "WEBHOOK";
 };
 
+export type Analytics = {
+  gtmId1: string;
+  gtmId2: string;
+  matomoId: string;
+  matomoUrl: string;
+};
+
 /**
  * `FormDefinition` is a typescript representation of `Schema`
  */
@@ -214,4 +221,5 @@ export type FormDefinition = {
   jwtKey?: string | undefined;
   toggle?: boolean | string | undefined;
   retryTimeoutSeconds?: number | undefined;
+  analytics?: Analytics;
 };

--- a/model/src/schema/schema.ts
+++ b/model/src/schema/schema.ts
@@ -209,6 +209,13 @@ const feeSchema = joi.object().keys({
   prefix: joi.string().optional(),
 });
 
+const analyticsSchema = joi.object().keys({
+  gtmId1: joi.string().allow("").optional(),
+  gtmId2: joi.string().allow("").optional(),
+  matomoId: joi.string().allow("").optional(),
+  matomoUrl: joi.string().uri().allow("").optional(),
+});
+
 const multiApiKeySchema = joi.object({
   test: joi.string().optional(),
   smoke: joi.string().optional(),
@@ -346,6 +353,7 @@ export const Schema = joi
     toggle: joi.alternatives().try(joi.boolean(), joi.string()).optional(),
     toggleRedirect: joi.string().optional(),
     retryTimeoutSeconds: joi.number().optional(),
+    analytics: analyticsSchema.optional(),
   });
 
 /**

--- a/runner/src/server/plugins/views.ts
+++ b/runner/src/server/plugins/views.ts
@@ -61,28 +61,35 @@ export default {
       `${path.dirname(resolve.sync("hmpo-components"))}/components`,
     ],
     isCached: !config.isDev,
-    context: (request: HapiRequest) => ({
-      appVersion: pkg.version,
-      assetPath: "/assets",
-      cookiesPolicy: request?.state?.cookies_policy,
-      serviceName: capitalize(config.serviceName),
-      feedbackLink: config.feedbackLink,
-      pageTitle: config.serviceName + " - GOV.UK",
-      analyticsAccount: config.analyticsAccount,
-      gtmId1: config.gtmId1,
-      gtmId2: config.gtmId2,
-      location: request?.app.location,
-      matomoId: config.matomoId,
-      matomoUrl: config.matomoUrl,
-      BROWSER_REFRESH_URL: config.browserRefreshUrl,
-      sessionTimeout: config.sessionTimeout,
-      skipTimeoutWarning: false,
-      serviceStartPage: config.serviceStartPage || "#",
-      privacyPolicyUrl: config.privacyPolicyUrl || "/help/privacy",
-      phaseTag: config.phaseTag,
-      navigation: request?.auth.isAuthenticated
-        ? [{ text: "Sign out", href: "/logout" }]
-        : null,
-    }),
+    context: (request: HapiRequest) => {
+      const id = request.params?.id;
+      const forms = request.server?.app?.forms;
+      const model = id && forms?.[id];
+      const analytics = model?.def?.analytics || {};
+
+      return {
+        appVersion: pkg.version,
+        assetPath: "/assets",
+        cookiesPolicy: request?.state?.cookies_policy,
+        serviceName: capitalize(config.serviceName),
+        feedbackLink: config.feedbackLink,
+        pageTitle: config.serviceName + " - GOV.UK",
+        analyticsAccount: config.analyticsAccount,
+        gtmId1: analytics.gtmId1 || "",
+        gtmId2: analytics.gtmId2 || "",
+        location: request?.app.location,
+        matomoId: analytics.matomoId || "",
+        matomoUrl: analytics.matomoUrl || "",
+        BROWSER_REFRESH_URL: config.browserRefreshUrl,
+        sessionTimeout: config.sessionTimeout,
+        skipTimeoutWarning: false,
+        serviceStartPage: config.serviceStartPage || "#",
+        privacyPolicyUrl: config.privacyPolicyUrl || "/help/privacy",
+        phaseTag: config.phaseTag,
+        navigation: request?.auth.isAuthenticated
+          ? [{ text: "Sign out", href: "/logout" }]
+          : null,
+      };
+    },
   },
 };


### PR DESCRIPTION
- Update server to dynamically inject analytics on a per-form basis, replacing the previous global-only setting.
- Enables each form to have its own tracking analytics configuration.
- Note: This ignores the global server-wide config! Existing forms should be updated to include analytics in their form definitions.

Format example:

"analytics": {
  "gtmId1": "string"; 
  "gtmId2": string;
  "matomoId": string; 
  "matomoUrl": string; 
}

This object is *optional*.
All items in this object are also *optional*.


## Type of change

- [✅] New feature (non-breaking change which adds functionality)
- [✅] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [✅] This change requires a documentation update

# How Has This Been Tested?

Tested locally on Firefox and Google Chrome by adding different analytics objects to forms. Verified in browser dev tools that the rendered source code contains the correct analytics settings per form. 

Note: DID NOT test with actual Matomo/Google Analytics.


# Checklist:

- [✅ ] I have performed a self-review of my own code
- [ ✅] I have commented my code, particularly in hard-to-understand areas
- [ ✅] I have made corresponding changes to the documentation and versioning

