### PR TITLE
Feat: Allow forms to use their own magic-link config

### DIFF
--- a/model/src/data-model/types.ts
+++ b/model/src/data-model/types.ts
@@ -214,4 +214,5 @@ export type FormDefinition = {
   jwtKey?: string | undefined;
   toggle?: boolean | string | undefined;
   retryTimeoutSeconds?: number | undefined;
+  magicLinkConfig?: string | undefined;
 };

--- a/model/src/schema/schema.ts
+++ b/model/src/schema/schema.ts
@@ -346,6 +346,7 @@ export const Schema = joi
     toggle: joi.alternatives().try(joi.boolean(), joi.string()).optional(),
     toggleRedirect: joi.string().optional(),
     retryTimeoutSeconds: joi.number().optional(),
+    magicLinkConfig: joi.string().optional(),
   });
 
 /**

--- a/runner/src/server/plugins/engine/pageControllers/MagicLinkRedirectController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/MagicLinkRedirectController.ts
@@ -4,7 +4,16 @@ import { HapiRequest, HapiResponseToolkit } from "server/types";
 export class MagicLinkRedirectController extends PageController {
   makeGetRouteHandler() {
     return async (request: HapiRequest, h: HapiResponseToolkit) => {
-      return h.redirect("/magic-link/start").code(302);
+    const id = request.params?.id;
+    const forms = request.server?.app?.forms;
+    const model = id && forms?.[id];
+    
+    // Fallback to the default Magic Link config used by CareOBRA
+    // WARNING: This has hardcoded values 
+    // You should define your own magicLinkConfig in your (main) form config   
+    const magicLinkConfig = model?.def?.magicLinkConfig ?? 'magic-link';
+    
+    return h.redirect(`/${magicLinkConfig}/start`).code(302);
     };
   }
 }


### PR DESCRIPTION
- Previously, all users were redirected to CareOBRA's form via a **hardcoded** config in MagicLinkRedirectController.ts

- Updated the controller to allow each form to specify its own magicLinkConfig, enabling flexible redirects per form

- Fallback remains for undefined, mainly for backwards compat purposes

Example to add to main form:

  "magicLinkConfig": "kls-magic-link",

replace **kls-magic-link** with your **_own_** magic-link config.

- [✓] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Locally.

# Checklist:

- [✓] I have performed a self-review of my own code
- [✓] I have commented my code, particularly in hard-to-understand areas

