### PR TITLE
feat/fix: URL construction for hmac email

### DIFF
--- a/runner/src/server/plugins/engine/pageControllers/MagicLinkSubmissionPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/MagicLinkSubmissionPageController.ts
@@ -192,7 +192,7 @@ export class MagicLinkSubmissionPageController extends PageController {
       }
 
       // Construct the magic link URL
-      const hmacUrlStart = "/magic-link/return?email=";
+      const hmacUrlStart = `/${model.basePath}/return?email=`
       const hmacUrl = hmacUrlStart.concat(
         email,
         "&request_time=",


### PR DESCRIPTION
- updated hmacurl construction to dynamically use the model's basepath instead of the hardcoded "magic-link" path.

- enables different magic-link forms to send emails that link to their specific pages, improving flexibility and reusability.


