### PR TITLE
Modify fileupload to send customSecurityHeaders

### DIFF
--- a/model/src/data-model/types.ts
+++ b/model/src/data-model/types.ts
@@ -226,6 +226,7 @@ export type FormDefinition = {
   invalidDomainRedirect?: string | undefined;
   analytics?: Analytics;
   webhookHmacSharedKey?: string | undefined;
+  fileUploadHmacSharedKey?: string | undefined;
   fullStartPage?: string | undefined;
   serviceName?: string | undefined;
 };

--- a/model/src/schema/schema.ts
+++ b/model/src/schema/schema.ts
@@ -358,6 +358,7 @@ export const Schema = joi
     invalidDomainRedirect: joi.string().optional(),
     analytics: analyticsSchema.optional(),
     webhookHmacSharedKey: joi.string().optional(),
+    fileUploadHmacSharedKey: joi.string().optional(),
     fullStartPage: joi.string().optional(),
     serviceName: joi.string().optional(),
   });

--- a/runner/src/server/plugins/engine/pluginHandlers/files/prehandlers/handleUpload.ts
+++ b/runner/src/server/plugins/engine/pluginHandlers/files/prehandlers/handleUpload.ts
@@ -46,7 +46,7 @@ export async function handleUpload(
     let response;
 
     try {
-      response = await uploadService.uploadDocuments(streams);
+      response = await uploadService.uploadDocuments(streams,request);
     } catch (err) {
       if (err.data?.res) {
         const { error } = uploadService.parsedDocumentUploadResponse(err.data);


### PR DESCRIPTION
- headers added to payload (see Commit d242c8c)
- added schemas for HMAC keys for this specific features (diff teams can use different keys for signature generation)
- Modified Upload service to take in more useful file types

