### PR TITLE
fix for broken training form output bug and back link

### DIFF
--- a/runner/src/server/forms/kls-magic-link.json
+++ b/runner/src/server/forms/kls-magic-link.json
@@ -161,11 +161,11 @@
     {
       "path": "/email-confirmed",
       "title": "Thank you for verifying your email",
+      "disableBackLink": true,
       "components": [
         {
           "name": "EmailConfirmed",
           "options": {},
-          "disableBackLink": true,
           "type": "Para",
           "content": "You will now be asked a series of questions. Please provide as much information as possible as this will help the UKHSA Knowledge and Library Services team deal with your enquiry promptly and accurately.<br><br><a href='/kls-path-1/which-organisation-do-you-work-for-DUPE' role='button' draggable='false' class='govuk-button' data-module='govuk-button' data-prevent-double-click='true'>Continue</button></a>",
           "schema": {}

--- a/runner/src/server/forms/kls-training-magic-link.json
+++ b/runner/src/server/forms/kls-training-magic-link.json
@@ -161,11 +161,11 @@
         {
             "title": "Thank you for verifying your email",
             "path": "/email-confirmed",
+            "disableBackLink": true,
             "components": [
                 {
                     "name": "EmailConfirmed",
                     "options": {},
-                    "disableBackLink": true,
                     "type": "Para",
                     "content": "You will now be asked a series of questions. Please provide as much information as possible as this will help the UKHSA Knowledge and Library Services team deal with your enquiry promptly and accurately.<br><br><a href='/kls-training/training-request-part-1' role='button' draggable='false' class='govuk-button' data-module='govuk-button' data-prevent-double-click='true'>Continue</button></a>",
                     "schema": {}
@@ -227,17 +227,12 @@
             "title": "KLS Training MagicLink",
             "type": "notify",
             "outputConfiguration": {
-            "name": "magiclink",
-            "title": "KLS Training MagicLink",
-            "type": "notify",
-            "outputConfiguration": {
                 "apiKey": "${KLSTrainingNotifyApiKey}",
                 "templateId": "${KLSTrainingNotifyTemplateId}",
                 "emailField": "email",
                 "addReferencesToPersonalisation": false,
                 "personalisation": ["email", "hmacSignature", "hmacExpiryTime"],
                 "hmacKey": "${KLSTrainingMagicLinkHmacKey}"
-                }     
             }
         }
     ],


### PR DESCRIPTION
#Description

Fix a bug with the output of the training magic link preventing it from being deployed
Moved "disableBackLink" out of the components section of email-confirmed pages