### PR TITLE
kls-magic-link-training.json duplicate line fix

### DIFF
--- a/runner/src/server/forms/kls-training-magic-link.json
+++ b/runner/src/server/forms/kls-training-magic-link.json
@@ -1,255 +1,250 @@
 {
-    "metadata": {},
-    "startPage": "/start",
-    "skipSummary": true,
-    "authentication": true,
-    "toggle": true,
-    "toggleRedirect": "/kls-training/training-request-part-1",
-    "magicLinkConfig": "kls-training-magic-link",
-    "allowedDomains": [
-        "ukhsa.gov.uk",
-        "dhsc.gov.uk",
-        "nhs.net",
-        "nhs.uk",
-        "gov.uk"
-    ],
-    "invalidDomainRedirect": "/kls-training-magic-link/your-email-is-not-on-our-approved-list",
-    "serviceName": "Knowledge and Library Services",
-    "fullStartPage": "/kls-training/start",
-    "pages": [
+  "metadata": {},
+  "startPage": "/start",
+  "skipSummary": true,
+  "authentication": true,
+  "toggle": true,
+  "toggleRedirect": "/kls-training/training-request-part-1",
+  "magicLinkConfig": "kls-training-magic-link",
+  "allowedDomains": [
+    "ukhsa.gov.uk",
+    "dhsc.gov.uk",
+    "nhs.net",
+    "nhs.uk",
+    "gov.uk"
+  ],
+  "invalidDomainRedirect": "/kls-training-magic-link/your-email-is-not-on-our-approved-list",
+  "serviceName": "Knowledge and Library Services",
+  "fullStartPage": "/kls-training/start",
+  "pages": [
+    {
+      "path": "/start",
+      "controller": "MagicLinkStartPageController",
+      "unauthenticated": true
+    },
+    {
+      "title": "Enter your email address",
+      "path": "/email",
+      "unauthenticated": true,
+      "continueButtonText": "Continue",
+      "showContinueButton": true,
+      "backLinkFallback": "/kls-training/training-request-part-1",
+      "components": [
         {
-            "path": "/start",
-            "controller": "MagicLinkStartPageController",
-            "unauthenticated": true
+          "name": "EmailIntro",
+          "options": {},
+          "type": "Para",
+          "content": "We need to email you a secure link to the service.<br><br>The link expires after 20 minutes.<br>",
+          "schema": {}
         },
         {
-            "title": "Enter your email address",
-            "path": "/email",
-            "unauthenticated": true,
-            "continueButtonText": "Continue",
-            "showContinueButton": true,
-            "backLinkFallback": "/kls-training/training-request-part-1",
-            "components": [
-                {
-                    "name": "EmailIntro",
-                    "options": {},
-                    "type": "Para",
-                    "content": "We need to email you a secure link to the service.<br><br>The link expires after 20 minutes.<br>",
-                    "schema": {}
-                },
-                {
-                    "type": "EmailAddressField",
-                    "title": "Enter your email address",
-                    "name": "email",
-                    "options": {
-                        "exposeToContext": true,
-                        "customValidationMessages": {
-                            "any.required": "Enter an email address",
-                            "any.only": "Enter an email address",
-                            "string.empty": "Enter an email address",
-                            "string.pattern.base": "Enter an email address in the correct format, like name@example.com"
-                        }
-                    },
-                    "hint": "Only email addresses that end in .gov.uk, nhs.uk, or nhs.net can be accepted."
-                },
-                {
-                    "name": "alert",
-                    "type": "ContentWithState",
-                    "options": {
-                        "exposeToContext": true,
-                        "stateVariable": "minutesRemaining"
-                    },
-                    "content": "{% if minutesRemaining %}<div class='alert'><div class='govuk-warning-text'><span class='govuk-warning-text__icon' aria-hidden='true'>!</span><strong class='govuk-warning-text__text'><span class='govuk-visually-hidden'>Warning</span>You must wait {% if minutesRemaining == 1 %}1 minute{% else %}{{ minutesRemaining }} minutes{% endif %} before resubmitting the email</strong></div></div>{% endif %}"
-                },
-                {
-                    "name": "PrivacyNotice",
-                    "options": {},
-                    "type": "Para",
-                    "content": "By continuing, you agree to our <a href='https://www.gov.uk/government/publications/ukhsa-privacy-notice' target='_blank'>privacy notice</a>.",
-                    "schema": {}
-                }
-            ],
-            "next": [
-                {
-                    "path": "/submit1"
-                }
-            ]
-        },
-        {
-            "path": "/submit1",
-            "controller": "MagicLinkFirstSubmitPageController"
-        },
-        {
-            "path": "/submit2",
-            "controller": "MagicLinkSecondSubmitPageController"
-        },
-        {
-            "path": "/check-your-email",
-            "title": "Check your email",
-            "unauthenticated": true,
-            "backLinkFallback": "/start",
-            "components": [
-                {
-                    "name": "SentAnotherEmail",
-                    "options": {},
-                    "type": "Para",
-                    "content": "We’ve sent an email to {{ email }}. <p class=\"govuk-body\">Click the link in the email to continue to access the Knowledge and Library Services form.</p> <br><br> <h2 class=\"govuk-heading-m\">If you've not received an email</h2><p class=\"govuk-body\">Check your spam or junk folder.<br><br>If you’ve not received the email, you can resubmit the email in 5 minutes.</p>",
-                    "schema": {}
-                },
-                {
-                    "name": "alert",
-                    "type": "ContentWithState",
-                    "options": {
-                        "exposeToContext": true,
-                        "stateVariable": "minutesRemaining"
-                    },
-                    "content": "{% if minutesRemaining %}<div class='alert'><div class='govuk-warning-text'><span class='govuk-warning-text__icon' aria-hidden='true'>!</span><strong class='govuk-warning-text__text'><span class='govuk-visually-hidden'>Warning</span>You must wait {% if minutesRemaining == 1 %}1 minute{% else %}{{ minutesRemaining }} minutes{% endif %} before resubmitting the email</strong></div></div>{% endif %}"
-                },
-                {
-                    "name": "SentAnotherEmailButton",
-                    "options": {},
-                    "type": "Para",
-                    "content": "<a href='/kls-training-magic-link/submit2' role='button' draggable='false' class='govuk-button' data-module='govuk-button' data-prevent-double-click='true'>Send a new email</button></a>",
-                    "schema": {}
-                }
-            ]
-        },
-        {
-            "backLinkFallback": "/kls-training-magic-link",
-            "path": "/your-email-is-not-on-our-approved-list",
-            "title": "Your email is not on our approved list",
-            "components": [
-                {
-                    "name": "GVrjNV",
-                    "options": {},
-                    "type": "Para",
-                    "content": " The email you provided does not match our approved email criteria. We only accept emails from goverment orgainsation limited to UKHSA, OHID, Local Authorities and the NHS (nhs.uk and nhs.net).<br>You can still contact the Knowledge and Library Services team via their <b>email</b>:<br> libraries@kls.ukhsa.gov.uk ",
-                    "schema": {}
-                }
-            ]
-        },
-        {
-            "path": "/resubmit-email",
-            "title": "We've sent you another email",
-            "unauthenticated": true,
-            "backLinkFallback": "/check-your-email",
-            "components": [
-                {
-                    "name": "SentAnotherEmail",
-                    "options": {},
-                    "type": "Para",
-                    "content": "We’ve sent another email to {{ email }}. <br><br> Click the link in the email to continue to report an access the Knowledge and Library Services. <br><br>",
-                    "schema": {}
-                },
-                {
-                    "name": "NotReceivedEmail",
-                    "options": {},
-                    "type": "Para",
-                    "title": "If you've not received an email",
-                    "content": "<h3 class=\"govuk-heading-m\">If you've not received an email</h3><p class=\"govuk-body\">Check your spam or junk folder.<br><br>If you’ve still not received the email in 5 minutes, you need to request a new link.</p><a href='/kls-training-magic-link' role='button' draggable='false' class='govuk-button' data-module='govuk-button' data-prevent-double-click='true'>Request a new link</button></a>",
-                    "schema": {}
-                }
-            ],
-            "next": []
-        },
-        {
-            "title": "Summary",
-            "path": "/summary",
-            "controller": "./pages/summary.js",
-            "components": []
-        },
-        {
-            "title": "Thank you for verifying your email",
-            "path": "/email-confirmed",
-            "components": [
-                {
-                    "name": "EmailConfirmed",
-                    "options": {},
-                    "disableBackLink": true,
-                    "type": "Para",
-                    "content": "You will now be asked a series of questions. Please provide as much information as possible as this will help the UKHSA Knowledge and Library Services team deal with your enquiry promptly and accurately.<br><br><a href='/kls-training/training-request-part-1' role='button' draggable='false' class='govuk-button' data-module='govuk-button' data-prevent-double-click='true'>Continue</button></a>",
-                    "schema": {}
-                }
-            ]
-        },
-        {
-            "title": "return",
-            "path": "/return",
-            "controller": "MagicLinkController",
-            "components": []
-        },
-        {
-            "path": "/incorrect-email",
-            "title": "Incorrect email link",
-            "components": [
-                {
-                    "name": "IncorrectEmail",
-                    "options": {},
-                    "type": "Para",
-                    "content": "The email you used does not match the email associated with this link.<br><br><a href='/kls-training-magic-link' role='button' draggable='false' class='govuk-button' data-module='govuk-button' data-prevent-double-click='true'>Request a new link</button></a>",
-                    "schema": {}
-                }
-            ]
-        },
-        {
-            "path": "/expired",
-            "title": "This link has expired",
-            "components": [
-                {
-                    "type": "Para",
-                    "title": "This link has expired",
-                    "content": "<a href='/kls-magic-training-link' role='button' draggable='false' class='govuk-button' data-module='govuk-button' data-prevent-double-click='true'>Request a new link</button></a>",
-                    "name": "blarGGH",
-                    "options": {},
-                    "schema": {}
-                }
-            ]
-        }
-    ],
-    "specialPages": {
-        "confirmationPage": {
-            "customText": {
-                "hidePanel": true,
-                "nextSteps": "<a href='/kls-training-magic-link/check-your-email' class='govuk-back-link'>Back</a><h1 class='govuk-heading-l'>We've sent you another email</h1><p class=\"govuk-body\">We’ve sent another email to {{ email }}. <br><br> Click the link in the email to continue to access the Knowledge and Library Services. </p><h3 class=\"govuk-heading-m\">If you've not received an email</h3><p class=\"govuk-body\">Check your spam or junk folder.<br><br>If you’ve still not received the email in 5 minutes, you need to request a new link.</p><a href='/kls-training-magic-link' role='button' draggable='false' class='govuk-button' data-module='govuk-button' data-prevent-double-click='true'>Request a new link</button></a>"
+          "type": "EmailAddressField",
+          "title": "Enter your email address",
+          "name": "email",
+          "options": {
+            "exposeToContext": true,
+            "customValidationMessages": {
+              "any.required": "Enter an email address",
+              "any.only": "Enter an email address",
+              "string.empty": "Enter an email address",
+              "string.pattern.base": "Enter an email address in the correct format, like name@example.com"
             }
-        }
-    },
-    "lists": [],
-    "sections": [],
-    "phaseBanner": {
-        "phase": "beta"
-    },
-    "conditions": [],
-    "fees": [],
-    "outputs": [
+          },
+          "hint": "Only email addresses that end in .gov.uk, nhs.uk, or nhs.net can be accepted."
+        },
         {
-            "name": "magiclink",
-            "title": "KLS Training MagicLink",
-            "type": "notify",
-            "outputConfiguration": {
-            "name": "magiclink",
-            "title": "KLS Training MagicLink",
-            "type": "notify",
-            "outputConfiguration": {
-                "apiKey": "${KLSTrainingNotifyApiKey}",
-                "templateId": "${KLSTrainingNotifyTemplateId}",
-                "emailField": "email",
-                "addReferencesToPersonalisation": false,
-                "personalisation": ["email", "hmacSignature", "hmacExpiryTime"],
-                "hmacKey": "${KLSTrainingMagicLinkHmacKey}"
-                }     
-            }
+          "name": "alert",
+          "type": "ContentWithState",
+          "options": {
+            "exposeToContext": true,
+            "stateVariable": "minutesRemaining"
+          },
+          "content": "{% if minutesRemaining %}<div class='alert'><div class='govuk-warning-text'><span class='govuk-warning-text__icon' aria-hidden='true'>!</span><strong class='govuk-warning-text__text'><span class='govuk-visually-hidden'>Warning</span>You must wait {% if minutesRemaining == 1 %}1 minute{% else %}{{ minutesRemaining }} minutes{% endif %} before resubmitting the email</strong></div></div>{% endif %}"
+        },
+        {
+          "name": "PrivacyNotice",
+          "options": {},
+          "type": "Para",
+          "content": "By continuing, you agree to our <a href='https://www.gov.uk/government/publications/ukhsa-privacy-notice' target='_blank'>privacy notice</a>.",
+          "schema": {}
         }
-    ],
-    "feedback": {
-        "feedbackForm": true,
-        "url": "/feedback"
+      ],
+      "next": [
+        {
+          "path": "/submit1"
+        }
+      ]
     },
-    "version": 2,
-    "feeOptions": {
-        "allowSubmissionWithoutPayment": true,
-        "maxAttempts": 3,
-        "showPaymentSkippedWarningPage": false
+    {
+      "path": "/submit1",
+      "controller": "MagicLinkFirstSubmitPageController"
     },
-    "jwtKey": "${KLSTrainingJwtKey}"
+    {
+      "path": "/submit2",
+      "controller": "MagicLinkSecondSubmitPageController"
+    },
+    {
+      "path": "/check-your-email",
+      "title": "Check your email",
+      "unauthenticated": true,
+      "backLinkFallback": "/start",
+      "components": [
+        {
+          "name": "SentAnotherEmail",
+          "options": {},
+          "type": "Para",
+          "content": "We’ve sent an email to {{ email }}. <p class=\"govuk-body\">Click the link in the email to continue to access the Knowledge and Library Services form.</p> <br><br> <h2 class=\"govuk-heading-m\">If you've not received an email</h2><p class=\"govuk-body\">Check your spam or junk folder.<br><br>If you’ve not received the email, you can resubmit the email in 5 minutes.</p>",
+          "schema": {}
+        },
+        {
+          "name": "alert",
+          "type": "ContentWithState",
+          "options": {
+            "exposeToContext": true,
+            "stateVariable": "minutesRemaining"
+          },
+          "content": "{% if minutesRemaining %}<div class='alert'><div class='govuk-warning-text'><span class='govuk-warning-text__icon' aria-hidden='true'>!</span><strong class='govuk-warning-text__text'><span class='govuk-visually-hidden'>Warning</span>You must wait {% if minutesRemaining == 1 %}1 minute{% else %}{{ minutesRemaining }} minutes{% endif %} before resubmitting the email</strong></div></div>{% endif %}"
+        },
+        {
+          "name": "SentAnotherEmailButton",
+          "options": {},
+          "type": "Para",
+          "content": "<a href='/kls-training-magic-link/submit2' role='button' draggable='false' class='govuk-button' data-module='govuk-button' data-prevent-double-click='true'>Send a new email</button></a>",
+          "schema": {}
+        }
+      ]
+    },
+    {
+      "backLinkFallback": "/kls-training-magic-link",
+      "path": "/your-email-is-not-on-our-approved-list",
+      "title": "Your email is not on our approved list",
+      "components": [
+        {
+          "name": "GVrjNV",
+          "options": {},
+          "type": "Para",
+          "content": " The email you provided does not match our approved email criteria. We only accept emails from goverment orgainsation limited to UKHSA, OHID, Local Authorities and the NHS (nhs.uk and nhs.net).<br>You can still contact the Knowledge and Library Services team via their <b>email</b>:<br> libraries@kls.ukhsa.gov.uk ",
+          "schema": {}
+        }
+      ]
+    },
+    {
+      "path": "/resubmit-email",
+      "title": "We've sent you another email",
+      "unauthenticated": true,
+      "backLinkFallback": "/check-your-email",
+      "components": [
+        {
+          "name": "SentAnotherEmail",
+          "options": {},
+          "type": "Para",
+          "content": "We’ve sent another email to {{ email }}. <br><br> Click the link in the email to continue to report an access the Knowledge and Library Services. <br><br>",
+          "schema": {}
+        },
+        {
+          "name": "NotReceivedEmail",
+          "options": {},
+          "type": "Para",
+          "title": "If you've not received an email",
+          "content": "<h3 class=\"govuk-heading-m\">If you've not received an email</h3><p class=\"govuk-body\">Check your spam or junk folder.<br><br>If you’ve still not received the email in 5 minutes, you need to request a new link.</p><a href='/kls-training-magic-link' role='button' draggable='false' class='govuk-button' data-module='govuk-button' data-prevent-double-click='true'>Request a new link</button></a>",
+          "schema": {}
+        }
+      ],
+      "next": []
+    },
+    {
+      "title": "Summary",
+      "path": "/summary",
+      "controller": "./pages/summary.js",
+      "components": []
+    },
+    {
+      "title": "Thank you for verifying your email",
+      "path": "/email-confirmed",
+      "components": [
+        {
+          "name": "EmailConfirmed",
+          "options": {},
+          "disableBackLink": true,
+          "type": "Para",
+          "content": "You will now be asked a series of questions. Please provide as much information as possible as this will help the UKHSA Knowledge and Library Services team deal with your enquiry promptly and accurately.<br><br><a href='/kls-training/training-request-part-1' role='button' draggable='false' class='govuk-button' data-module='govuk-button' data-prevent-double-click='true'>Continue</button></a>",
+          "schema": {}
+        }
+      ]
+    },
+    {
+      "title": "return",
+      "path": "/return",
+      "controller": "MagicLinkController",
+      "components": []
+    },
+    {
+      "path": "/incorrect-email",
+      "title": "Incorrect email link",
+      "components": [
+        {
+          "name": "IncorrectEmail",
+          "options": {},
+          "type": "Para",
+          "content": "The email you used does not match the email associated with this link.<br><br><a href='/kls-training-magic-link' role='button' draggable='false' class='govuk-button' data-module='govuk-button' data-prevent-double-click='true'>Request a new link</button></a>",
+          "schema": {}
+        }
+      ]
+    },
+    {
+      "path": "/expired",
+      "title": "This link has expired",
+      "components": [
+        {
+          "type": "Para",
+          "title": "This link has expired",
+          "content": "<a href='/kls-magic-training-link' role='button' draggable='false' class='govuk-button' data-module='govuk-button' data-prevent-double-click='true'>Request a new link</button></a>",
+          "name": "blarGGH",
+          "options": {},
+          "schema": {}
+        }
+      ]
+    }
+  ],
+  "specialPages": {
+    "confirmationPage": {
+      "customText": {
+        "hidePanel": true,
+        "nextSteps": "<a href='/kls-training-magic-link/check-your-email' class='govuk-back-link'>Back</a><h1 class='govuk-heading-l'>We've sent you another email</h1><p class=\"govuk-body\">We’ve sent another email to {{ email }}. <br><br> Click the link in the email to continue to access the Knowledge and Library Services. </p><h3 class=\"govuk-heading-m\">If you've not received an email</h3><p class=\"govuk-body\">Check your spam or junk folder.<br><br>If you’ve still not received the email in 5 minutes, you need to request a new link.</p><a href='/kls-training-magic-link' role='button' draggable='false' class='govuk-button' data-module='govuk-button' data-prevent-double-click='true'>Request a new link</button></a>"
+      }
+    }
+  },
+  "lists": [],
+  "sections": [],
+  "phaseBanner": {
+    "phase": "beta"
+  },
+  "conditions": [],
+  "fees": [],
+  "outputs": [
+    {
+      "name": "magiclink",
+      "title": "KLS Training MagicLink",
+      "type": "notify",
+      "outputConfiguration": {
+        "apiKey": "${KLSTrainingNotifyApiKey}",
+        "templateId": "${KLSTrainingNotifyTemplateId}",
+        "emailField": "email",
+        "addReferencesToPersonalisation": false,
+        "personalisation": ["email", "hmacSignature", "hmacExpiryTime"],
+        "hmacKey": "${KLSTrainingMagicLinkHmacKey}"
+      }
+    }
+  ],
+  "feedback": {
+    "feedbackForm": true,
+    "url": "/feedback"
+  },
+  "version": 2,
+  "feeOptions": {
+    "allowSubmissionWithoutPayment": true,
+    "maxAttempts": 3,
+    "showPaymentSkippedWarningPage": false
+  },
+  "jwtKey": "${KLSTrainingJwtKey}"
 }


### PR DESCRIPTION
Removing duplicate lines from kls-magic-link-training.json, formatting has made the git diff look significant but screenshot shows the lines which were removed: 

<img width="435" alt="Screenshot 2025-06-25 at 09 39 21" src="https://github.com/user-attachments/assets/7ca3efcb-33e1-49cc-bcef-2c351f476a81" />
