### PR TITLE
disable back link on page after email confirmed

### DIFF
--- a/runner/src/server/forms/kls-path-1.json
+++ b/runner/src/server/forms/kls-path-1.json
@@ -738,6 +738,7 @@
     {
       "path": "/which-organisation-do-you-work-for-DUPE",
       "title": "Which organisation do you work for?",
+      "disableBackLink": true,
       "components": [
         {
           "name": "wyvXTj",

--- a/runner/src/server/forms/kls-training.json
+++ b/runner/src/server/forms/kls-training.json
@@ -82,6 +82,7 @@
         {
             "path": "/training-request-part-1",
             "title": "Training request part 1",
+            "disableBackLink": true,
             "components": [
                 {
                     "name": "sqQXGM",


### PR DESCRIPTION
# Description
Remove back link on page after email confirmed as it would take you to What is your Org page