### PR TITLE
bug-fix: Fix cookies banner issue

### DIFF
--- a/runner/src/server/plugins/router.ts
+++ b/runner/src/server/plugins/router.ts
@@ -149,6 +149,8 @@ export default {
             if (referrer) {
               redirectPath = new URL(referrer).pathname;
             }
+            
+            const cookieName = form?.name || `${url}Page`;
 
             return h.redirect(redirectPath).state(
               "cookies_policy",
@@ -158,7 +160,7 @@ export default {
                 essential: true,
                 analytics: accept ? "on" : "off",
                 usage: accept,
-                name: form.name,
+                name: cookieName,
               },
               {
                 isHttpOnly: false,


### PR DESCRIPTION
# Description
- The cookie banner keeps reappearing, this occurs on dev, staging and even in production!
- After some (annoying) debugging, I found issues with acquiring the form name (undefined) and have looked at what the name was being used for and it seems very little/none, I believe setting a default version based on the form will suffice.
- This is specific to the POST request (submission of cookie preference choice on the cookie banner).
- Needs further testing on dev and staging environments, as local HTTP testing differs from those.

Production issue with accepting cookies -> this causes a bug that causes the banner to reload the banner even though it's supposed to be set.
![image](https://github.com/user-attachments/assets/d0a36d03-52b8-4058-8bcc-b0c83b3ac30e)


## Type of change

- [✓] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Only locally (HTTP). Will require testing in dev and staging runners.

# Checklist:

- [✓] I have performed a self-review of my own code
- [✓ ] I have commented my code, particularly in hard-to-understand areas

