### PR TITLE
move 'skip to main content' to top

### DIFF
--- a/runner/src/server/views/layout.html
+++ b/runner/src/server/views/layout.html
@@ -94,6 +94,9 @@
 
 
 {% block header %}
+  {% if not cookiesPolicy.isSet %}
+    {% include "partials/cookie-banner.html" %}
+  {% endif %}
   {{ govukHeader({
     homepageUrl: "https://gov.uk",
     containerClasses: "govuk-width-container",
@@ -108,14 +111,9 @@
       rebrand: true
     })
   }}
-
 {% endblock %}
 
 {% block bodyStart %}
-  {% if not cookiesPolicy.isSet %}
-    {% include "partials/cookie-banner.html" %}
-  {% endif %}
-
   {% if gtmId1 %}
     <noscript>
       <iframe src="https://www.googletagmanager.com/ns.html?id={{ gtmId1 }}" height="0" width="0" style="display:none;visibility:hidden"></iframe>


### PR DESCRIPTION
# Description
CHANGE MADE UPSTREAM: PLEASE SEE https://github.com/XGovFormBuilder/digital-form-builder/pull/1335
I've moved the cookies banner to be lower than "Skip to main content" to comply with our accessibility review:
"Screen reader needs to pick up "Skip to main content" first before cookies.

That way users can skip the flow directly into the body.

It is best for the DOM to be in this order
1. Skip link (first)
2. Cookie banner 
3. Header
4. Phase banner
5. Main content
6.  Footer"


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
-
# How Has This Been Tested?

local testing on chrome

# Checklist:

- [X] I have performed a self-review of my own code
