### PR TITLE
Updated the value sent to SalesForce when selecting supply issues rel…

### DIFF
--- a/runner/src/server/forms/ReportAnOutbreak.json
+++ b/runner/src/server/forms/ReportAnOutbreak.json
@@ -3370,11 +3370,11 @@
       "items": [
         {
           "text": "COVID-19: access to treatments",
-          "value": "COVID-19: access to treatments"
+          "value": "COVID-19 - access to treatments"
         },
         {
           "text": "COVID-19: LFD test kit supply",
-          "value": "COVID-19: LFD test kit supply"
+          "value": "COVID-19 - LFD test kit supply"
         },
         {
           "text": "Hand hygiene",


### PR DESCRIPTION
For the ReportAnOutbreak data that is sent into Salesforce on the /ipc/ screen, we need to remove the colon from the COVID-19 requests because the data in Salesforce is mapped in this way:

COVID-19: access to treatments:pink;

Which breaks because of the colon. We need to send this into SalesForce:

COVID-19 - access to treatments

So that we can map it in this way:

COVID-19 - access to treatments:pink;

This request has come from: [INC0189098], the form has been built and tested locally but we require a deployment into PreProd in order to test it in SalesForce
