### PR TITLE
Null value when empty rows passed into mergeRows

### DIFF
--- a/runner/src/server/transforms/summaryDetails/mergeRows.ts
+++ b/runner/src/server/transforms/summaryDetails/mergeRows.ts
@@ -22,7 +22,7 @@ export function mergeRows(
               ...item,
               name: to.toLowerCase().replace(" ", "_"),
               ...{ label: to, title: to, rawValue: to },
-              value: values.length === 0 ? "Not supplied" : values.join(joiner),
+              value: values.length === 0 ? null : values.join(joiner),
             };
           }
           return item;


### PR DESCRIPTION
# Description

When values in the rows merged by the mergeRows transformer are empty, the value of the new row should be null rather than "Not supplied" - the FE will automatically display the words "Not supplied" for rows with null values

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update