### PR TITLE
adding digital accessibility email to allowed domains

### DIFF
--- a/runner/src/server/forms/kls-magic-link.json
+++ b/runner/src/server/forms/kls-magic-link.json
@@ -9,7 +9,7 @@
     "gtmId1": "GTM-WLKKLMQB"
   },
   "magicLinkConfig": "kls-magic-link",
-  "allowedDomains": ["ukhsa.gov.uk", "dhsc.gov.uk", "nhs.net", "nhs.uk", "gov.uk", "nccpentest.com", "nccgroup.com"],
+  "allowedDomains": ["ukhsa.gov.uk", "dhsc.gov.uk", "nhs.net", "nhs.uk", "gov.uk", "nccpentest.com", "nccgroup.com", "digitalaccessibilitycentre.org"],
   "invalidDomainRedirect": "/kls-magic-link/your-email-is-not-on-our-approved-list",
   "serviceName": "UKHSA Knowledge and Library Services (KLS)",
   "name": "UKHSA Knowledge and Library Services (KLS)",

--- a/runner/src/server/forms/kls-training-magic-link.json
+++ b/runner/src/server/forms/kls-training-magic-link.json
@@ -16,7 +16,8 @@
         "dhsc.gov.uk",
         "nhs.net",
         "nhs.uk",
-        "gov.uk"
+        "gov.uk",
+        "digitalaccessibilitycentre.org"
     ],
     "invalidDomainRedirect": "/kls-training-magic-link/your-email-is-not-on-our-approved-list",
     "fullStartPage": "https://gov.uk/guidance/ukhsa-knowledge-and-library-services",


### PR DESCRIPTION
# Description

Adding digitalaccessibilitycentre.org to allowed domains for accessibility audit.

# How Has This Been Tested?

locally on chrome 

# Checklist:

- [X] I have performed a self-review of my own code
