### PR TITLE
fix: avoid duplicate form submissions

### DIFF
--- a/runner/src/server/views/custom-summary.html
+++ b/runner/src/server/views/custom-summary.html
@@ -1,8 +1,4 @@
 {% from "components/checkboxes/macro.njk" import govukCheckboxes %}
-<<<<<<< HEAD
-=======
-{% from "button/macro.njk" import govukButton %}
->>>>>>> 557ffccd49c07b623f6b1e50d6a84008df21d3ce
 {% from "summary-list/macro.njk" import govukSummaryList %}
 {% extends 'layout.html' %}
 

--- a/runner/src/server/views/custom-summary.html
+++ b/runner/src/server/views/custom-summary.html
@@ -139,7 +139,6 @@
     </div>
   </div>
 
-
   <script type="text/javascript">
     document.addEventListener('DOMContentLoaded', function () {
       const button = document.querySelector('button[data-prevent-double-click="true"]');
@@ -148,7 +147,6 @@
           e.preventDefault();
           button.disabled = true;
 
-          // Find the closest form and submit it
           const form = button.closest('form');
           if (form) {
             form.submit();

--- a/runner/src/server/views/custom-summary.html
+++ b/runner/src/server/views/custom-summary.html
@@ -139,15 +139,23 @@
     </div>
   </div>
 
+
   <script type="text/javascript">
     document.addEventListener('DOMContentLoaded', function () {
       const button = document.querySelector('button[data-prevent-double-click="true"]');
       if (button) {
-        button.addEventListener('click', function () {
-          // Disable immediately to prevent multiple clicks
+        button.addEventListener('click', function (e) {
+          e.preventDefault();
           button.disabled = true;
+
+          // Find the closest form and submit it
+          const form = button.closest('form');
+          if (form) {
+            form.submit();
+          }
         });
       }
     });
   </script>
+
 {% endblock %}

--- a/runner/src/server/views/custom-summary.html
+++ b/runner/src/server/views/custom-summary.html
@@ -117,7 +117,7 @@
                   </div>
                 {% endif %}
 
-                <button data-prevent-double-click="true" class="govuk-button" data-module="govuk-button">
+                <button type="submit" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button">
                     {% if fees and fees.details|length %}
                         Submit and pay
                     {% else %}

--- a/runner/src/server/views/custom-summary.html
+++ b/runner/src/server/views/custom-summary.html
@@ -1,4 +1,5 @@
 {% from "components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "summary-list/macro.njk" import govukSummaryList %}
 {% extends 'layout.html' %}
 
@@ -117,13 +118,17 @@
                   </div>
                 {% endif %}
 
-                <button type="submit" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button">
-                    {% if fees and fees.details|length %}
-                        Submit and pay
-                    {% else %}
-                        Confirm and send
-                    {% endif %}
-                </button>
+                {% if fees and fees.details|length %}
+                  {{ govukButton({
+                    text: "Submit and pay",
+                    preventDoubleClick: true
+                  }) }}
+                {% else %}
+                  {{ govukButton({
+                    text: "Confirm and send",
+                    preventDoubleClick: true
+                  }) }}
+                {% endif %}
 
                 {% if showPaymentSkippedWarningPage %}
                 <div class="govuk-body">

--- a/runner/src/server/views/custom-summary.html
+++ b/runner/src/server/views/custom-summary.html
@@ -1,5 +1,4 @@
 {% from "components/checkboxes/macro.njk" import govukCheckboxes %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "summary-list/macro.njk" import govukSummaryList %}
 {% extends 'layout.html' %}
 
@@ -118,17 +117,13 @@
                   </div>
                 {% endif %}
 
-                {% if fees and fees.details|length %}
-                  {{ govukButton({
-                    text: "Submit and pay",
-                    preventDoubleClick: true
-                  }) }}
-                {% else %}
-                  {{ govukButton({
-                    text: "Confirm and send",
-                    preventDoubleClick: true
-                  }) }}
-                {% endif %}
+                <button type="submit" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button">
+                    {% if fees and fees.details|length %}
+                        Submit and pay
+                    {% else %}
+                        Confirm and send
+                    {% endif %}
+                </button>
 
                 {% if showPaymentSkippedWarningPage %}
                 <div class="govuk-body">
@@ -143,4 +138,16 @@
       </div>
     </div>
   </div>
+
+  <script type="text/javascript">
+    document.addEventListener('DOMContentLoaded', function () {
+      const button = document.querySelector('button[data-prevent-double-click="true"]');
+      if (button) {
+        button.addEventListener('click', function () {
+          // Disable immediately to prevent multiple clicks
+          button.disabled = true;
+        });
+      }
+    });
+  </script>
 {% endblock %}


### PR DESCRIPTION
# Description

## Context

This ticket was raised following an incident observed in production where duplicate submissions were sent through the "Report an Outbreak" form.

Upon investigation, it was identified that the issue stems from the default behavior of the GOV.UK Design System's button component. Specifically, the data-prevent-double-click attribute only disables the button for one second after the initial click. This short debounce window allows users to unintentionally submit the form multiple times if they click again after the timeout.

A similar [issue](https://github.com/alphagov/govuk-design-system-backlog/issues/34#issuecomment-2056433103) was reported by another service using the [same component](https://github.com/alphagov/govuk-frontend/blob/bba51e3e5a3aec8f0456b7e0da993753fc699861/packages/govuk-frontend/src/govuk/components/button/button.mjs), which led them to implement a custom JavaScript solution to ensure the form is submitted only once.

To address this, we’ve implemented a fix that disables the button immediately and manually submits the form using JavaScript, bypassing the GOV.UK module’s debounce logic. This ensures that the form submission is reliably single-triggered, preventing duplicates.

## Changes

- Disable submit button on "click" using javascript.

## Type of change

What is the type of change you are making?

- [ ] Chore or documentation (non-breaking change that does not add functionality)
- [ ] ADR (Architectural Decision Record, non-breaking change that documents or proposes a decision)
- [ ] Refactor (non-breaking change that improves code quality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### PR title

PR titles should be prefixed with the type of change you are making, based on the [README.md#versioning](https://github.com/XGovFormBuilder/digital-form-builder?tab=readme-ov-file#versioning).
This is so that when performing a squash merge, the PR title is automatically used as the commit message.

Have you updated the PR title to match the type of change you are making?

- [x] Yes
- [ ] No, I need help or guidance

# Testing

<!--
Several departments use XGovFormBuilder in production.
Automated tests help ensure that changes do not break existing functionality for another department.

Maintainers are sympathetic to the time constraints of government departments, but please try to be good citizens and add tests when possible.
-->

## Automated tests

Have you added automated tests?

- [ ] Yes, unit or integration tests
- [ ] Yes, end-to-end (cypress) tests
- [ ] No, tests are not required for this change
- [x] No, I need help or guidance
- [ ] No (explain why tests are not required or can't be added at this time)

## Manual tests

Have you manually tested your changes?

- [X] Yes
- [ ] No, manual tests are not required or sufficiently covered by automated tests

Have you attached an example form JSON or snippet for the reviewer in this PR?

- [ ] Yes
- [ ] No, any existing form can be used
- [X] No, it is not required or not applicable

### Steps to test

1. Navigate to the "Report an Outbreak" form.
2. Fill in all required fields and proceed through the form until the final step.
3. At the end of the journey, click the "Confirm and send" button.
4. Observe that the button becomes disabled immediately after clicking, preventing further interaction.
5. Attempt to click the button again — it should remain disabled.
6. Verify in Salesforce that only one submission has been recorded for the test entry.

# Documentation

Have you updated the documentation?

- [ ] Yes, I have updated [./docs](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs) for this change since additional explanation or steps to use/configure the feature is required
- [ ] Yes, I have added or updated an [ADR](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs/adr) for this change since it is large, complex, or has significant architectural implications
- [ ] Yes, I have added inline comments for hard-to-understand areas
- [X] No, I am not sure if documentation is required
- [ ] No, documentation is not required for this change

# Discussion

> [!WARNING]
>
> Large or complex changes may require discussion with the maintainers before they can be merged. If it has not yet been discussed, it may delay the review process

Have you discussed this change with the maintainers?

- [ ] Yes, I have discussed this change with the maintainers on slack, email or via GitHub issues
- [ ] Yes, this change is an ADR to help kick-off discussion
- [ ] No, this change is small and does not require discussion
- [ ] No, I am not sure if one is required
