### PR TITLE
feature: custom ConfirmationSessionTimeout per form setup, including fixes for magiclink retry and auth_token 

### DIFF
--- a/model/src/data-model/types.ts
+++ b/model/src/data-model/types.ts
@@ -230,4 +230,6 @@ export type FormDefinition = {
   fileUploadHmacSharedKey?: string | undefined;
   fullStartPage?: string | undefined;
   serviceName?: string | undefined;
+  confirmationTimeout: number | undefined;
+  
 };

--- a/model/src/schema/schema.ts
+++ b/model/src/schema/schema.ts
@@ -362,6 +362,7 @@ export const Schema = joi
     fileUploadHmacSharedKey: joi.string().optional(),
     fullStartPage: joi.string().optional(),
     serviceName: joi.string().optional(),
+    confirmationTimeout: joi.number().greater(0).optional()
   });
 
 /**

--- a/runner/src/server/plugins/applicationStatus/index.ts
+++ b/runner/src/server/plugins/applicationStatus/index.ts
@@ -3,6 +3,7 @@ import { HapiRequest, HapiResponseToolkit } from "../../types";
 import { retryPay } from "./retryPay";
 import { handleUserWithConfirmationViewModel } from "./handleUserWithConfirmationViewModel";
 import { checkUserCompletedSummary } from "./checkUserCompletedSummary";
+import config from "../../config";
 
 import Joi from "joi";
 import {
@@ -73,10 +74,27 @@ const index = {
             viewModel.name = form.name;
             viewModel.feedbackLink = form.def.feedback.url;
 
-            await cacheService.setConfirmationState(request, {
-              confirmation: viewModel,
-            });
+            const formTimeout =  request.server?.app?.forms?.[request.params?.id]?.def?.confirmationTimeout
+            ?? config.confirmationSessionTimeout;
+            
+            await cacheService.setConfirmationState(request, { confirmation: viewModel }, formTimeout);
             await cacheService.clearState(request);
+
+            h.unstate("magicLinkRetry", {
+            path: "/",
+            isSecure: true,
+            isHttpOnly: true,
+            encoding: "base64json",
+            strictHeader: true,
+            });
+
+            h.unstate("auth_token", {
+            path: "/",
+            isSecure: true,
+            isHttpOnly: true,
+            encoding: "none",
+            isSameSite: "Lax",
+            });
 
             return h.view("confirmation", viewModel);
           },

--- a/runner/src/server/services/cacheService.ts
+++ b/runner/src/server/services/cacheService.ts
@@ -73,9 +73,10 @@ export class CacheService {
     return await this.cache.get(key);
   }
 
-  async setConfirmationState(request: HapiRequest, viewModel) {
+async setConfirmationState(request: HapiRequest, viewModel, ttl?: number) {
     const key = this.Key(request, ADDITIONAL_IDENTIFIER.Confirmation);
-    return this.cache.set(key, viewModel, confirmationSessionTimeout);
+    const timeout = ttl ?? confirmationSessionTimeout; 
+    return this.cache.set(key, viewModel, timeout);
   }
 
   async createSession(


### PR DESCRIPTION
# Description

This change allows a form-maker to create a custom form which allows users to submit one form after another. It also fixes some minor bugs to do with header tokens not being removed from the front-end upon succesful form submission. 

## Context

The current setup enforces a 20 minute wait time or a cookie refresh via a browser's console to submit a new form. This change enables individual forms to have a custom time limit which can be very low to allow users forms one after another - please note this change does not enable parallel form submissions, it is consecutive.  

This change only affects forms who OPT-IN. The default time limit is kept if this feature is not used. 

## Changes

- Feat: optional form variable confirmationTimeout can now be set (note: 0 is not allowed) in a form's config. 
- Fix: magiclinkRetry and auth_token not correctly being cleared after a complete submission. 

## Type of change

What is the type of change you are making?


- [X] New feature (non-breaking change which adds functionality)


### PR title

PR titles should be prefixed with the type of change you are making, based on the [README.md#versioning](https://github.com/XGovFormBuilder/digital-form-builder?tab=readme-ov-file#versioning).
This is so that when performing a squash merge, the PR title is automatically used as the commit message.

Have you updated the PR title to match the type of change you are making?

- [X] Yes


# Testing

<!--
Several departments use XGovFormBuilder in production.
Automated tests help ensure that changes do not break existing functionality for another department.

Maintainers are sympathetic to the time constraints of government departments, but please try to be good citizens and add tests when possible.
-->

## Automated tests

Have you added automated tests?

- [X] No (explain why tests are not required or can't be added at this time)
 
This feature is opt-in and will be tested via End-to-End tests which will be updated when deployed. If we wish to test it in another way, feel free to suggest it and help if capable.


## Manual tests

Have you manually tested your changes?

- [X] Yes


Have you attached an example form JSON or snippet for the reviewer in this PR?

- [X] No, any existing form can be used

Just add this:   "confirmationTimeout": 10,
for example to the top of the config - see image:

<img width="737" height="211" alt="image" src="https://github.com/user-attachments/assets/d6838459-ff94-45f5-8443-9254fb13e7f1" />


### Steps to test

<!--
Only fill out this section if you answered "Yes" to manually testing your changes.

In this section
- describe the tests that you ran to verify your changes
- provide instructions and a form JSON or snippet so we can reproduce the test if necessary

If uploading a form JSON, use the "attach files" feature in GitHub PR.
-->

Using the new feature:

1. Insert the  "confirmationTimeout": 10 
2. Submit a form
3. go back to the form's start page
4. Submit another form
5. Check backend - to see if two submissions submitted.

no "confirmationTimeout": 
2. Submit a form
3. go back to the form's start page
4. Submit another form
5. There should be no two submissions going in.



# Documentation

Have you updated the documentation?

- [X] No, I am not sure if documentation is required


# Discussion

> [!WARNING]
>
> Large or complex changes may require discussion with the maintainers before they can be merged. If it has not yet been discussed, it may delay the review process

Have you discussed this change with the maintainers?

I have discussed this interally within UKHSA - KLS and L2/L3 teams. 

- [X] No, this change is small and does not require discussion

