### PR TITLE
Close contact form bugfixing

### DIFF
--- a/runner/src/server/forms/close-contact-form-cca-nl1-dev.json
+++ b/runner/src/server/forms/close-contact-form-cca-nl1-dev.json
@@ -2,7 +2,7 @@
   "metadata": {},
   "startPage": "/start",
   "fullStartPage": "start",
-  "name": "Contract tracing CCA",
+  "name": "Contact tracing CCA",
   "pages": [
     {
       "title": "Record close contact details for a member of the public",
@@ -148,15 +148,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your first (given) name"
+          "title": "Your first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your last (family) name"
+          "title": "Your last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -179,7 +193,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -233,15 +253,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their first (given) name"
+          "title": "Their first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their last (family) name"
+          "title": "Their last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -295,7 +329,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -459,15 +499,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -508,7 +562,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -599,15 +659,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -648,7 +722,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -739,15 +819,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -788,7 +882,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -879,15 +979,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -928,7 +1042,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1019,15 +1139,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1068,7 +1202,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1159,15 +1299,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1208,7 +1362,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1299,15 +1459,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1348,7 +1522,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1439,15 +1619,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1488,7 +1682,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1579,15 +1779,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1628,7 +1842,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1719,15 +1939,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1768,7 +2002,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1871,15 +2111,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1920,7 +2174,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2008,15 +2268,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2057,7 +2331,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2145,15 +2425,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2194,7 +2488,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2282,15 +2582,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2331,7 +2645,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2419,15 +2739,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2468,7 +2802,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2556,15 +2896,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2605,7 +2959,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2693,15 +3053,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2742,7 +3116,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2830,15 +3210,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2879,7 +3273,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2967,15 +3367,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3016,7 +3430,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -3104,15 +3524,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3153,7 +3587,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",

--- a/runner/src/server/forms/close-contact-form-cca-nl1-test.json
+++ b/runner/src/server/forms/close-contact-form-cca-nl1-test.json
@@ -2,7 +2,7 @@
   "metadata": {},
   "startPage": "/start",
   "fullStartPage": "start",
-  "name": "Contract tracing CCA",
+  "name": "Contact tracing CCA",
   "pages": [
     {
       "title": "Record close contact details for a member of the public",
@@ -148,15 +148,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your first (given) name"
+          "title": "Your first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your last (family) name"
+          "title": "Your last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -179,7 +193,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -233,15 +253,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their first (given) name"
+          "title": "Their first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their last (family) name"
+          "title": "Their last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -295,7 +329,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -459,15 +499,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -508,7 +562,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -599,15 +659,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -648,7 +722,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -739,15 +819,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -788,7 +882,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -879,15 +979,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -928,7 +1042,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1019,15 +1139,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1068,7 +1202,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1159,15 +1299,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1208,7 +1362,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1299,15 +1459,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1348,7 +1522,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1439,15 +1619,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1488,7 +1682,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1579,15 +1779,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1628,7 +1842,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1719,15 +1939,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1768,7 +2002,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1871,15 +2111,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1920,7 +2174,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2008,15 +2268,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2057,7 +2331,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2145,15 +2425,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2194,7 +2488,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2282,15 +2582,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2331,7 +2645,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2419,15 +2739,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2468,7 +2802,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2556,15 +2896,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2605,7 +2959,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2693,15 +3053,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2742,7 +3116,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2830,15 +3210,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2879,7 +3273,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2967,15 +3367,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3016,7 +3430,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -3104,15 +3524,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3153,7 +3587,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",

--- a/runner/src/server/forms/close-contact-form-cca-nl4.json
+++ b/runner/src/server/forms/close-contact-form-cca-nl4.json
@@ -2,7 +2,7 @@
   "metadata": {},
   "startPage": "/start",
   "fullStartPage": "start",
-  "name": "Contract tracing CCA",
+  "name": "Contact tracing CCA",
   "pages": [
     {
       "title": "Record close contact details for a member of the public",
@@ -148,15 +148,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your first (given) name"
+          "title": "Your first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your last (family) name"
+          "title": "Your last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -179,7 +193,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -233,15 +253,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their first (given) name"
+          "title": "Their first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their last (family) name"
+          "title": "Their last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -295,7 +329,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -459,15 +499,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -508,7 +562,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -599,15 +659,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -648,7 +722,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -739,15 +819,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -788,7 +882,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -879,15 +979,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -928,7 +1042,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1019,15 +1139,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1068,7 +1202,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1159,15 +1299,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1208,7 +1362,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1299,15 +1459,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1348,7 +1522,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1439,15 +1619,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1488,7 +1682,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1579,15 +1779,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1628,7 +1842,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1719,15 +1939,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1768,7 +2002,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1871,15 +2111,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1920,7 +2174,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2008,15 +2268,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2057,7 +2331,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2145,15 +2425,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2194,7 +2488,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2282,15 +2582,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2331,7 +2645,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2419,15 +2739,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2468,7 +2802,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2556,15 +2896,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2605,7 +2959,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2693,15 +3053,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2742,7 +3116,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2830,15 +3210,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2879,7 +3273,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2967,15 +3367,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3016,7 +3430,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -3104,15 +3524,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3153,7 +3587,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",

--- a/runner/src/server/forms/close-contact-form-cca-nl5.json
+++ b/runner/src/server/forms/close-contact-form-cca-nl5.json
@@ -2,7 +2,7 @@
   "metadata": {},
   "startPage": "/start",
   "fullStartPage": "start",
-  "name": "Contract tracing CCA",
+  "name": "Contact tracing CCA",
   "pages": [
     {
       "title": "Record close contact details for a member of the public",
@@ -148,15 +148,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your first (given) name"
+          "title": "Your first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your last (family) name"
+          "title": "Your last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -179,7 +193,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -233,15 +253,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their first (given) name"
+          "title": "Their first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their last (family) name"
+          "title": "Their last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -295,7 +329,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -459,15 +499,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -508,7 +562,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -599,15 +659,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -648,7 +722,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -739,15 +819,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -788,7 +882,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -879,15 +979,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -928,7 +1042,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1019,15 +1139,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1068,7 +1202,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1159,15 +1299,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1208,7 +1362,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1299,15 +1459,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1348,7 +1522,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1439,15 +1619,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1488,7 +1682,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1579,15 +1779,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1628,7 +1842,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1719,15 +1939,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1768,7 +2002,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1871,15 +2111,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1920,7 +2174,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2008,15 +2268,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2057,7 +2331,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2145,15 +2425,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2194,7 +2488,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2282,15 +2582,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2331,7 +2645,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2419,15 +2739,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2468,7 +2802,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2556,15 +2896,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2605,7 +2959,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2693,15 +3053,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2742,7 +3116,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2830,15 +3210,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2879,7 +3273,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2967,15 +3367,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3016,7 +3430,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -3104,15 +3524,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3153,7 +3587,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",

--- a/runner/src/server/forms/close-contact-form-cca-nl7.json
+++ b/runner/src/server/forms/close-contact-form-cca-nl7.json
@@ -2,7 +2,7 @@
   "metadata": {},
   "startPage": "/start",
   "fullStartPage": "start",
-  "name": "Contract tracing CCA",
+  "name": "Contact tracing CCA",
   "pages": [
     {
       "title": "Record close contact details for a member of the public",
@@ -148,15 +148,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your first (given) name"
+          "title": "Your first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your last (family) name"
+          "title": "Your last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -179,7 +193,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -233,15 +253,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their first (given) name"
+          "title": "Their first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their last (family) name"
+          "title": "Their last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -295,7 +329,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -459,15 +499,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -508,7 +562,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -599,15 +659,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -648,7 +722,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -739,15 +819,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -788,7 +882,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -879,15 +979,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -928,7 +1042,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1019,15 +1139,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1068,7 +1202,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1159,15 +1299,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1208,7 +1362,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1299,15 +1459,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1348,7 +1522,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1439,15 +1619,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1488,7 +1682,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1579,15 +1779,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1628,7 +1842,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1719,15 +1939,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1768,7 +2002,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1871,15 +2111,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1920,7 +2174,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2008,15 +2268,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2057,7 +2331,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2145,15 +2425,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2194,7 +2488,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2282,15 +2582,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2331,7 +2645,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2419,15 +2739,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2468,7 +2802,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2556,15 +2896,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2605,7 +2959,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2693,15 +3053,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2742,7 +3116,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2830,15 +3210,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2879,7 +3273,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2967,15 +3367,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3016,7 +3430,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -3104,15 +3524,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3153,7 +3587,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",

--- a/runner/src/server/forms/close-contact-form-cca-nl8.json
+++ b/runner/src/server/forms/close-contact-form-cca-nl8.json
@@ -2,7 +2,7 @@
   "metadata": {},
   "startPage": "/start",
   "fullStartPage": "start",
-  "name": "Contract tracing CCA",
+  "name": "Contact tracing CCA",
   "pages": [
     {
       "title": "Record close contact details for a member of the public",
@@ -148,15 +148,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your first (given) name"
+          "title": "Your first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your last (family) name"
+          "title": "Your last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -179,7 +193,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -233,15 +253,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their first (given) name"
+          "title": "Their first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their last (family) name"
+          "title": "Their last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -295,7 +329,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -459,15 +499,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -508,7 +562,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -599,15 +659,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -648,7 +722,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -739,15 +819,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -788,7 +882,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -879,15 +979,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -928,7 +1042,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1019,15 +1139,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1068,7 +1202,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1159,15 +1299,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1208,7 +1362,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1299,15 +1459,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1348,7 +1522,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1439,15 +1619,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1488,7 +1682,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1579,15 +1779,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1628,7 +1842,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1719,15 +1939,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1768,7 +2002,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1871,15 +2111,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1920,7 +2174,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2008,15 +2268,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2057,7 +2331,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2145,15 +2425,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2194,7 +2488,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2282,15 +2582,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2331,7 +2645,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2419,15 +2739,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2468,7 +2802,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2556,15 +2896,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2605,7 +2959,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2693,15 +3053,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2742,7 +3116,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2830,15 +3210,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2879,7 +3273,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2967,15 +3367,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3016,7 +3430,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -3104,15 +3524,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3153,7 +3587,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",

--- a/runner/src/server/forms/close-contact-form-cca-uat.json
+++ b/runner/src/server/forms/close-contact-form-cca-uat.json
@@ -2,7 +2,7 @@
   "metadata": {},
   "startPage": "/start",
   "fullStartPage": "start",
-  "name": "Contract tracing CCA",
+  "name": "Contact tracing CCA",
   "pages": [
     {
       "title": "Record close contact details for a member of the public",
@@ -148,15 +148,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your first (given) name"
+          "title": "Your first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your last (family) name"
+          "title": "Your last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -179,7 +193,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -233,15 +253,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their first (given) name"
+          "title": "Their first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their last (family) name"
+          "title": "Their last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -295,7 +329,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -459,15 +499,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -508,7 +562,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -599,15 +659,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -648,7 +722,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -739,15 +819,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -788,7 +882,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -879,15 +979,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -928,7 +1042,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1019,15 +1139,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1068,7 +1202,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1159,15 +1299,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1208,7 +1362,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1299,15 +1459,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1348,7 +1522,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1439,15 +1619,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1488,7 +1682,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1579,15 +1779,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1628,7 +1842,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1719,15 +1939,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1768,7 +2002,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1871,15 +2111,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1920,7 +2174,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2008,15 +2268,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2057,7 +2331,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2145,15 +2425,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2194,7 +2488,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2282,15 +2582,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2331,7 +2645,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2419,15 +2739,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2468,7 +2802,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2556,15 +2896,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2605,7 +2959,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2693,15 +3053,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2742,7 +3116,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2830,15 +3210,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2879,7 +3273,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2967,15 +3367,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3016,7 +3430,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -3104,15 +3524,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3153,7 +3587,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",

--- a/runner/src/server/forms/close-contact-form-cca.json
+++ b/runner/src/server/forms/close-contact-form-cca.json
@@ -2,7 +2,7 @@
   "metadata": {},
   "startPage": "/start",
   "fullStartPage": "start",
-  "name": "Contract tracing CCA",
+  "name": "Contact tracing CCA",
   "pages": [
     {
       "title": "Record close contact details for a member of the public",
@@ -148,15 +148,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your first (given) name"
+          "title": "Your first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your last (family) name"
+          "title": "Your last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -179,7 +193,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -233,15 +253,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their first (given) name"
+          "title": "Their first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their last (family) name"
+          "title": "Their last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -295,7 +329,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -459,15 +499,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -508,7 +562,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -599,15 +659,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -648,7 +722,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -739,15 +819,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -788,7 +882,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -879,15 +979,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -928,7 +1042,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1019,15 +1139,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1068,7 +1202,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1159,15 +1299,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1208,7 +1362,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1299,15 +1459,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1348,7 +1522,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1439,15 +1619,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1488,7 +1682,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1579,15 +1779,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1628,7 +1842,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1719,15 +1939,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1768,7 +2002,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1871,15 +2111,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1920,7 +2174,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2008,15 +2268,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2057,7 +2331,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2145,15 +2425,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2194,7 +2488,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2282,15 +2582,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2331,7 +2645,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2419,15 +2739,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2468,7 +2802,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2556,15 +2896,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2605,7 +2959,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2693,15 +3053,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2742,7 +3116,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2830,15 +3210,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2879,7 +3273,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2967,15 +3367,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3016,7 +3430,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -3104,15 +3524,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3153,7 +3587,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",

--- a/runner/src/server/forms/close-contact-form-hpt-nl1-dev.json
+++ b/runner/src/server/forms/close-contact-form-hpt-nl1-dev.json
@@ -2,7 +2,7 @@
   "metadata": {},
   "startPage": "/start",
   "fullStartPage": "start",
-  "name": "Contract tracing",
+  "name": "Contact tracing",
   "pages": [
     {
       "title": "Tell us about people you've been in close contact with",
@@ -146,15 +146,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your first (given) name"
+          "title": "Your first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your last (family) name"
+          "title": "Your last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -183,7 +197,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -237,15 +257,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their first (given) name"
+          "title": "Their first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their last (family) name"
+          "title": "Their last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -299,7 +333,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -463,15 +503,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -512,7 +566,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -603,15 +663,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -652,7 +726,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -743,15 +823,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -792,7 +886,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -883,15 +983,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -932,7 +1046,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1023,15 +1143,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1072,7 +1206,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1163,15 +1303,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1212,7 +1366,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1303,15 +1463,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1352,7 +1526,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1443,15 +1623,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1492,7 +1686,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1583,15 +1783,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1632,7 +1846,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1723,15 +1943,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1772,7 +2006,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1875,15 +2115,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1924,7 +2178,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2012,15 +2272,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2061,7 +2335,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2149,15 +2429,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2198,7 +2492,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2286,15 +2586,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2335,7 +2649,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2423,15 +2743,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2472,7 +2806,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2560,15 +2900,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2609,7 +2963,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2697,15 +3057,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2746,7 +3120,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2834,15 +3214,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2883,7 +3277,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2971,15 +3371,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3020,7 +3434,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -3108,15 +3528,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3157,7 +3591,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",

--- a/runner/src/server/forms/close-contact-form-hpt-nl1-test.json
+++ b/runner/src/server/forms/close-contact-form-hpt-nl1-test.json
@@ -2,7 +2,7 @@
   "metadata": {},
   "startPage": "/start",
   "fullStartPage": "start",
-  "name": "Contract tracing",
+  "name": "Contact tracing",
   "pages": [
     {
       "title": "Tell us about people you've been in close contact with",
@@ -146,15 +146,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your first (given) name"
+          "title": "Your first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your last (family) name"
+          "title": "Your last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -183,7 +197,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -237,15 +257,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their first (given) name"
+          "title": "Their first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their last (family) name"
+          "title": "Their last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -299,7 +333,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -463,15 +503,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -512,7 +566,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -603,15 +663,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -652,7 +726,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -743,15 +823,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -792,7 +886,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -883,15 +983,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -932,7 +1046,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1023,15 +1143,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1072,7 +1206,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1163,15 +1303,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1212,7 +1366,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1303,15 +1463,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1352,7 +1526,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1443,15 +1623,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1492,7 +1686,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1583,15 +1783,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1632,7 +1846,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1723,15 +1943,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1772,7 +2006,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1875,15 +2115,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1924,7 +2178,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2012,15 +2272,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2061,7 +2335,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2149,15 +2429,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2198,7 +2492,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2286,15 +2586,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2335,7 +2649,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2423,15 +2743,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2472,7 +2806,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2560,15 +2900,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2609,7 +2963,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2697,15 +3057,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2746,7 +3120,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2834,15 +3214,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2883,7 +3277,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2971,15 +3371,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3020,7 +3434,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -3108,15 +3528,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3157,7 +3591,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",

--- a/runner/src/server/forms/close-contact-form-hpt-nl4.json
+++ b/runner/src/server/forms/close-contact-form-hpt-nl4.json
@@ -2,7 +2,7 @@
   "metadata": {},
   "startPage": "/start",
   "fullStartPage": "start",
-  "name": "Contract tracing",
+  "name": "Contact tracing",
   "pages": [
     {
       "title": "Tell us about people you've been in close contact with",
@@ -146,15 +146,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your first (given) name"
+          "title": "Your first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your last (family) name"
+          "title": "Your last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -183,7 +197,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -237,15 +257,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their first (given) name"
+          "title": "Their first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their last (family) name"
+          "title": "Their last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -299,7 +333,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -463,15 +503,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -512,7 +566,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -603,15 +663,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -652,7 +726,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -743,15 +823,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -792,7 +886,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -883,15 +983,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -932,7 +1046,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1023,15 +1143,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1072,7 +1206,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1163,15 +1303,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1212,7 +1366,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1303,15 +1463,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1352,7 +1526,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1443,15 +1623,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1492,7 +1686,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1583,15 +1783,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1632,7 +1846,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1723,15 +1943,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1772,7 +2006,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1875,15 +2115,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1924,7 +2178,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2012,15 +2272,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2061,7 +2335,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2149,15 +2429,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2198,7 +2492,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2286,15 +2586,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2335,7 +2649,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2423,15 +2743,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2472,7 +2806,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2560,15 +2900,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2609,7 +2963,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2697,15 +3057,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2746,7 +3120,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2834,15 +3214,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2883,7 +3277,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2971,15 +3371,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3020,7 +3434,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -3108,15 +3528,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3157,7 +3591,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",

--- a/runner/src/server/forms/close-contact-form-hpt-nl5.json
+++ b/runner/src/server/forms/close-contact-form-hpt-nl5.json
@@ -2,7 +2,7 @@
   "metadata": {},
   "startPage": "/start",
   "fullStartPage": "start",
-  "name": "Contract tracing",
+  "name": "Contact tracing",
   "pages": [
     {
       "title": "Tell us about people you've been in close contact with",
@@ -146,15 +146,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your first (given) name"
+          "title": "Your first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your last (family) name"
+          "title": "Your last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -183,7 +197,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -237,15 +257,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their first (given) name"
+          "title": "Their first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their last (family) name"
+          "title": "Their last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -299,7 +333,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -463,15 +503,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -512,7 +566,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -603,15 +663,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -652,7 +726,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -743,15 +823,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -792,7 +886,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -883,15 +983,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -932,7 +1046,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1023,15 +1143,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1072,7 +1206,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1163,15 +1303,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1212,7 +1366,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1303,15 +1463,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1352,7 +1526,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1443,15 +1623,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1492,7 +1686,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1583,15 +1783,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1632,7 +1846,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1723,15 +1943,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1772,7 +2006,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1875,15 +2115,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1924,7 +2178,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2012,15 +2272,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2061,7 +2335,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2149,15 +2429,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2198,7 +2492,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2286,15 +2586,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2335,7 +2649,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2423,15 +2743,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2472,7 +2806,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2560,15 +2900,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2609,7 +2963,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2697,15 +3057,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2746,7 +3120,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2834,15 +3214,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2883,7 +3277,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2971,15 +3371,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3020,7 +3434,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -3108,15 +3528,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3157,7 +3591,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",

--- a/runner/src/server/forms/close-contact-form-hpt-nl7.json
+++ b/runner/src/server/forms/close-contact-form-hpt-nl7.json
@@ -2,7 +2,7 @@
   "metadata": {},
   "startPage": "/start",
   "fullStartPage": "start",
-  "name": "Contract tracing",
+  "name": "Contact tracing",
   "pages": [
     {
       "title": "Tell us about people you've been in close contact with",
@@ -146,15 +146,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your first (given) name"
+          "title": "Your first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your last (family) name"
+          "title": "Your last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -183,7 +197,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -237,15 +257,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their first (given) name"
+          "title": "Their first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their last (family) name"
+          "title": "Their last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -299,7 +333,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -463,15 +503,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -512,7 +566,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -603,15 +663,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -652,7 +726,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -743,15 +823,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -792,7 +886,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -883,15 +983,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -932,7 +1046,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1023,15 +1143,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1072,7 +1206,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1163,15 +1303,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1212,7 +1366,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1303,15 +1463,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1352,7 +1526,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1443,15 +1623,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1492,7 +1686,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1583,15 +1783,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1632,7 +1846,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1723,15 +1943,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1772,7 +2006,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1875,15 +2115,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1924,7 +2178,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2012,15 +2272,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2061,7 +2335,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2149,15 +2429,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2198,7 +2492,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2286,15 +2586,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2335,7 +2649,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2423,15 +2743,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2472,7 +2806,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2560,15 +2900,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2609,7 +2963,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2697,15 +3057,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2746,7 +3120,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2834,15 +3214,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2883,7 +3277,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2971,15 +3371,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3020,7 +3434,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -3108,15 +3528,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3157,7 +3591,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",

--- a/runner/src/server/forms/close-contact-form-hpt-nl8.json
+++ b/runner/src/server/forms/close-contact-form-hpt-nl8.json
@@ -2,7 +2,7 @@
   "metadata": {},
   "startPage": "/start",
   "fullStartPage": "start",
-  "name": "Contract tracing",
+  "name": "Contact tracing",
   "pages": [
     {
       "title": "Tell us about people you've been in close contact with",
@@ -146,15 +146,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your first (given) name"
+          "title": "Your first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your last (family) name"
+          "title": "Your last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -183,7 +197,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -237,15 +257,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their first (given) name"
+          "title": "Their first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their last (family) name"
+          "title": "Their last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -299,7 +333,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -463,15 +503,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -512,7 +566,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -603,15 +663,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -652,7 +726,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -743,15 +823,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -792,7 +886,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -883,15 +983,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -932,7 +1046,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1023,15 +1143,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1072,7 +1206,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1163,15 +1303,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1212,7 +1366,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1303,15 +1463,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1352,7 +1526,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1443,15 +1623,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1492,7 +1686,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1583,15 +1783,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1632,7 +1846,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1723,15 +1943,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1772,7 +2006,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1875,15 +2115,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1924,7 +2178,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2012,15 +2272,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2061,7 +2335,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2149,15 +2429,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2198,7 +2492,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2286,15 +2586,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2335,7 +2649,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2423,15 +2743,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2472,7 +2806,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2560,15 +2900,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2609,7 +2963,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2697,15 +3057,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2746,7 +3120,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2834,15 +3214,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2883,7 +3277,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2971,15 +3371,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3020,7 +3434,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -3108,15 +3528,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3157,7 +3591,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",

--- a/runner/src/server/forms/close-contact-form-hpt-uat.json
+++ b/runner/src/server/forms/close-contact-form-hpt-uat.json
@@ -2,7 +2,7 @@
   "metadata": {},
   "startPage": "/start",
   "fullStartPage": "start",
-  "name": "Contract tracing",
+  "name": "Contact tracing",
   "pages": [
     {
       "title": "Tell us about people you've been in close contact with",
@@ -146,15 +146,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your first (given) name"
+          "title": "Your first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your last (family) name"
+          "title": "Your last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -183,7 +197,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -237,15 +257,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their first (given) name"
+          "title": "Their first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their last (family) name"
+          "title": "Their last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -299,7 +333,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -463,15 +503,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -512,7 +566,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -603,15 +663,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -652,7 +726,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -743,15 +823,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -792,7 +886,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -883,15 +983,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -932,7 +1046,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1023,15 +1143,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1072,7 +1206,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1163,15 +1303,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1212,7 +1366,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1303,15 +1463,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1352,7 +1526,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1443,15 +1623,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1492,7 +1686,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1583,15 +1783,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1632,7 +1846,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1723,15 +1943,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1772,7 +2006,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1875,15 +2115,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1924,7 +2178,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2012,15 +2272,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2061,7 +2335,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2149,15 +2429,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2198,7 +2492,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2286,15 +2586,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2335,7 +2649,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2423,15 +2743,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2472,7 +2806,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2560,15 +2900,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2609,7 +2963,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2697,15 +3057,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2746,7 +3120,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2834,15 +3214,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2883,7 +3277,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2971,15 +3371,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3020,7 +3434,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -3108,15 +3528,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3157,7 +3591,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",

--- a/runner/src/server/forms/close-contact-form-hpt.json
+++ b/runner/src/server/forms/close-contact-form-hpt.json
@@ -2,7 +2,7 @@
   "metadata": {},
   "startPage": "/start",
   "fullStartPage": "start",
-  "name": "Contract tracing",
+  "name": "Contact tracing",
   "pages": [
     {
       "title": "Tell us about people you've been in close contact with",
@@ -146,15 +146,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your first (given) name"
+          "title": "Your first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your last (family) name"
+          "title": "Your last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -183,7 +197,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -237,15 +257,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their first (given) name"
+          "title": "Their first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their last (family) name"
+          "title": "Their last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -299,7 +333,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -463,15 +503,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -512,7 +566,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -603,15 +663,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -652,7 +726,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -743,15 +823,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -792,7 +886,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -883,15 +983,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -932,7 +1046,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1023,15 +1143,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1072,7 +1206,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1163,15 +1303,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1212,7 +1366,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1303,15 +1463,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1352,7 +1526,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1443,15 +1623,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1492,7 +1686,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1583,15 +1783,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1632,7 +1846,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1723,15 +1943,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1772,7 +2006,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1875,15 +2115,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1924,7 +2178,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2012,15 +2272,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2061,7 +2335,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2149,15 +2429,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2198,7 +2492,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2286,15 +2586,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2335,7 +2649,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2423,15 +2743,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2472,7 +2806,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2560,15 +2900,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2609,7 +2963,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2697,15 +3057,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2746,7 +3120,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2834,15 +3214,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2883,7 +3277,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2971,15 +3371,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3020,7 +3434,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -3108,15 +3528,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3157,7 +3591,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",

--- a/runner/src/server/forms/close-contact-form-nl1-dev.json
+++ b/runner/src/server/forms/close-contact-form-nl1-dev.json
@@ -2,7 +2,7 @@
   "metadata": {},
   "startPage": "/start",
   "fullStartPage": "start",
-  "name": "Contract tracing",
+  "name": "Contact tracing",
   "pages": [
     {
       "title": "Tell us about people you've been in close contact with",
@@ -145,15 +145,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your first (given) name"
+          "title": "Your first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your last (family) name"
+          "title": "Your last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -182,7 +196,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -236,15 +256,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their first (given) name"
+          "title": "Their first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their last (family) name"
+          "title": "Their last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -298,7 +332,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -462,15 +502,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -511,7 +565,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -602,15 +662,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -651,7 +725,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -742,15 +822,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -791,7 +885,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -882,15 +982,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -931,7 +1045,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1022,15 +1142,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1071,7 +1205,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1162,15 +1302,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1211,7 +1365,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1302,15 +1462,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1351,7 +1525,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1442,15 +1622,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1491,7 +1685,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1582,15 +1782,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1631,7 +1845,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1722,15 +1942,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1771,7 +2005,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1874,15 +2114,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1923,7 +2177,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2011,15 +2271,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2060,7 +2334,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2148,15 +2428,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2197,7 +2491,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2285,15 +2585,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2334,7 +2648,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2422,15 +2742,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2471,7 +2805,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2559,15 +2899,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2608,7 +2962,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2696,15 +3056,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2745,7 +3119,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2833,15 +3213,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2882,7 +3276,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2970,15 +3370,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3019,7 +3433,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -3107,15 +3527,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3156,7 +3590,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",

--- a/runner/src/server/forms/close-contact-form-nl1-test.json
+++ b/runner/src/server/forms/close-contact-form-nl1-test.json
@@ -2,7 +2,7 @@
   "metadata": {},
   "startPage": "/start",
   "fullStartPage": "start",
-  "name": "Contract tracing",
+  "name": "Contact tracing",
   "pages": [
     {
       "title": "Tell us about people you've been in close contact with",
@@ -145,15 +145,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your first (given) name"
+          "title": "Your first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your last (family) name"
+          "title": "Your last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -182,7 +196,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -236,15 +256,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their first (given) name"
+          "title": "Their first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their last (family) name"
+          "title": "Their last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -298,7 +332,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -462,15 +502,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -511,7 +565,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -602,15 +662,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -651,7 +725,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -742,15 +822,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -791,7 +885,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -882,15 +982,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -931,7 +1045,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1022,15 +1142,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1071,7 +1205,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1162,15 +1302,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1211,7 +1365,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1302,15 +1462,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1351,7 +1525,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1442,15 +1622,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1491,7 +1685,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1582,15 +1782,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1631,7 +1845,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1722,15 +1942,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1771,7 +2005,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1874,15 +2114,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1923,7 +2177,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2011,15 +2271,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2060,7 +2334,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2148,15 +2428,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2197,7 +2491,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2285,15 +2585,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2334,7 +2648,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2422,15 +2742,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2471,7 +2805,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2559,15 +2899,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2608,7 +2962,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2696,15 +3056,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2745,7 +3119,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2833,15 +3213,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2882,7 +3276,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2970,15 +3370,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3019,7 +3433,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -3107,15 +3527,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3156,7 +3590,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",

--- a/runner/src/server/forms/close-contact-form-nl4.json
+++ b/runner/src/server/forms/close-contact-form-nl4.json
@@ -2,7 +2,7 @@
   "metadata": {},
   "startPage": "/start",
   "fullStartPage": "start",
-  "name": "Contract tracing",
+  "name": "Contact tracing",
   "pages": [
     {
       "title": "Tell us about people you've been in close contact with",
@@ -145,15 +145,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your first (given) name"
+          "title": "Your first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your last (family) name"
+          "title": "Your last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -182,7 +196,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -236,15 +256,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their first (given) name"
+          "title": "Their first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their last (family) name"
+          "title": "Their last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -298,7 +332,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -462,15 +502,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -511,7 +565,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -602,15 +662,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -651,7 +725,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -742,15 +822,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -791,7 +885,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -882,15 +982,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -931,7 +1045,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1022,15 +1142,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1071,7 +1205,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1162,15 +1302,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1211,7 +1365,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1302,15 +1462,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1351,7 +1525,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1442,15 +1622,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1491,7 +1685,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1582,15 +1782,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1631,7 +1845,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1722,15 +1942,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1771,7 +2005,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1874,15 +2114,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1923,7 +2177,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2011,15 +2271,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2060,7 +2334,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2148,15 +2428,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2197,7 +2491,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2285,15 +2585,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2334,7 +2648,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2422,15 +2742,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2471,7 +2805,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2559,15 +2899,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2608,7 +2962,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2696,15 +3056,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2745,7 +3119,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2833,15 +3213,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2882,7 +3276,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2970,15 +3370,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3019,7 +3433,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -3107,15 +3527,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3156,7 +3590,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",

--- a/runner/src/server/forms/close-contact-form-nl5.json
+++ b/runner/src/server/forms/close-contact-form-nl5.json
@@ -2,7 +2,7 @@
   "metadata": {},
   "startPage": "/start",
   "fullStartPage": "start",
-  "name": "Contract tracing",
+  "name": "Contact tracing",
   "pages": [
     {
       "title": "Tell us about people you've been in close contact with",
@@ -145,15 +145,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your first (given) name"
+          "title": "Your first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your last (family) name"
+          "title": "Your last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -182,7 +196,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -236,15 +256,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their first (given) name"
+          "title": "Their first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their last (family) name"
+          "title": "Their last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -298,7 +332,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -462,15 +502,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -511,7 +565,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -602,15 +662,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -651,7 +725,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -742,15 +822,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -791,7 +885,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -882,15 +982,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -931,7 +1045,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1022,15 +1142,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1071,7 +1205,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1162,15 +1302,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1211,7 +1365,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1302,15 +1462,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1351,7 +1525,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1442,15 +1622,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1491,7 +1685,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1582,15 +1782,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1631,7 +1845,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1722,15 +1942,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1771,7 +2005,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1874,15 +2114,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1923,7 +2177,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2011,15 +2271,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2060,7 +2334,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2148,15 +2428,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2197,7 +2491,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2285,15 +2585,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2334,7 +2648,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2422,15 +2742,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2471,7 +2805,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2559,15 +2899,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2608,7 +2962,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2696,15 +3056,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2745,7 +3119,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2833,15 +3213,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2882,7 +3276,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2970,15 +3370,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3019,7 +3433,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -3107,15 +3527,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3156,7 +3590,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",

--- a/runner/src/server/forms/close-contact-form-nl7.json
+++ b/runner/src/server/forms/close-contact-form-nl7.json
@@ -2,7 +2,7 @@
   "metadata": {},
   "startPage": "/start",
   "fullStartPage": "start",
-  "name": "Contract tracing",
+  "name": "Contact tracing",
   "pages": [
     {
       "title": "Tell us about people you've been in close contact with",
@@ -145,15 +145,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your first (given) name"
+          "title": "Your first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your last (family) name"
+          "title": "Your last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -182,7 +196,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -236,15 +256,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their first (given) name"
+          "title": "Their first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their last (family) name"
+          "title": "Their last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -298,7 +332,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -462,15 +502,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -511,7 +565,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -602,15 +662,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -651,7 +725,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -742,15 +822,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -791,7 +885,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -882,15 +982,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -931,7 +1045,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1022,15 +1142,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1071,7 +1205,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1162,15 +1302,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1211,7 +1365,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1302,15 +1462,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1351,7 +1525,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1442,15 +1622,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1491,7 +1685,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1582,15 +1782,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1631,7 +1845,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1722,15 +1942,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1771,7 +2005,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1874,15 +2114,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1923,7 +2177,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2011,15 +2271,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2060,7 +2334,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2148,15 +2428,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2197,7 +2491,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2285,15 +2585,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2334,7 +2648,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2422,15 +2742,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2471,7 +2805,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2559,15 +2899,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2608,7 +2962,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2696,15 +3056,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2745,7 +3119,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2833,15 +3213,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2882,7 +3276,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2970,15 +3370,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3019,7 +3433,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -3107,15 +3527,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3156,7 +3590,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",

--- a/runner/src/server/forms/close-contact-form-nl8.json
+++ b/runner/src/server/forms/close-contact-form-nl8.json
@@ -2,7 +2,7 @@
   "metadata": {},
   "startPage": "/start",
   "fullStartPage": "start",
-  "name": "Contract tracing",
+  "name": "Contact tracing",
   "pages": [
     {
       "title": "Tell us about people you've been in close contact with",
@@ -145,15 +145,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your first (given) name"
+          "title": "Your first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your last (family) name"
+          "title": "Your last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -182,7 +196,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -236,15 +256,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their first (given) name"
+          "title": "Their first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their last (family) name"
+          "title": "Their last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -298,7 +332,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -462,15 +502,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -511,7 +565,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -602,15 +662,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -651,7 +725,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -742,15 +822,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -791,7 +885,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -882,15 +982,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -931,7 +1045,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1022,15 +1142,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1071,7 +1205,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1162,15 +1302,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1211,7 +1365,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1302,15 +1462,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1351,7 +1525,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1442,15 +1622,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1491,7 +1685,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1582,15 +1782,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1631,7 +1845,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1722,15 +1942,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1771,7 +2005,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1874,15 +2114,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1923,7 +2177,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2011,15 +2271,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2060,7 +2334,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2148,15 +2428,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2197,7 +2491,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2285,15 +2585,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2334,7 +2648,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2422,15 +2742,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2471,7 +2805,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2559,15 +2899,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2608,7 +2962,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2696,15 +3056,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2745,7 +3119,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2833,15 +3213,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2882,7 +3276,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2970,15 +3370,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3019,7 +3433,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -3107,15 +3527,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3156,7 +3590,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",

--- a/runner/src/server/forms/close-contact-form-uat.json
+++ b/runner/src/server/forms/close-contact-form-uat.json
@@ -2,7 +2,7 @@
   "metadata": {},
   "startPage": "/start",
   "fullStartPage": "start",
-  "name": "Contract tracing",
+  "name": "Contact tracing",
   "pages": [
     {
       "title": "Tell us about people you've been in close contact with",
@@ -145,15 +145,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your first (given) name"
+          "title": "Your first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your last (family) name"
+          "title": "Your last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -182,7 +196,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -236,15 +256,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their first (given) name"
+          "title": "Their first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their last (family) name"
+          "title": "Their last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -298,7 +332,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -462,15 +502,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -511,7 +565,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -602,15 +662,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -651,7 +725,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -742,15 +822,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -791,7 +885,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -882,15 +982,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -931,7 +1045,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1022,15 +1142,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1071,7 +1205,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1162,15 +1302,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1211,7 +1365,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1302,15 +1462,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1351,7 +1525,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1442,15 +1622,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1491,7 +1685,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1582,15 +1782,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1631,7 +1845,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1722,15 +1942,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1771,7 +2005,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1874,15 +2114,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1923,7 +2177,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2011,15 +2271,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2060,7 +2334,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2148,15 +2428,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2197,7 +2491,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2285,15 +2585,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2334,7 +2648,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2422,15 +2742,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2471,7 +2805,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2559,15 +2899,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2608,7 +2962,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2696,15 +3056,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2745,7 +3119,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2833,15 +3213,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2882,7 +3276,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2970,15 +3370,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3019,7 +3433,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -3107,15 +3527,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3156,7 +3590,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",

--- a/runner/src/server/forms/close-contact-form.json
+++ b/runner/src/server/forms/close-contact-form.json
@@ -2,7 +2,7 @@
   "metadata": {},
   "startPage": "/start",
   "fullStartPage": "start",
-  "name": "Contract tracing",
+  "name": "Contact tracing",
   "pages": [
     {
       "title": "Tell us about people you've been in close contact with",
@@ -145,15 +145,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your first (given) name"
+          "title": "Your first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Your last (family) name"
+          "title": "Your last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -182,7 +196,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -236,15 +256,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their first (given) name"
+          "title": "Their first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Their last (family) name"
+          "title": "Their last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "VnYxYja",
@@ -298,7 +332,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -462,15 +502,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -511,7 +565,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -602,15 +662,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -651,7 +725,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -742,15 +822,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -791,7 +885,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -882,15 +982,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -931,7 +1045,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1022,15 +1142,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1071,7 +1205,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1162,15 +1302,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1211,7 +1365,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1302,15 +1462,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1351,7 +1525,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1442,15 +1622,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1491,7 +1685,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1582,15 +1782,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1631,7 +1845,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1722,15 +1942,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "First (given) name"
+          "title": "First (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Last (family) name"
+          "title": "Last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1771,7 +2005,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -1874,15 +2114,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -1923,7 +2177,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2011,15 +2271,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2060,7 +2334,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2148,15 +2428,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2197,7 +2491,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2285,15 +2585,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2334,7 +2648,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2422,15 +2742,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2471,7 +2805,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2559,15 +2899,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2608,7 +2962,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2696,15 +3056,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2745,7 +3119,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2833,15 +3213,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -2882,7 +3276,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -2970,15 +3370,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3019,7 +3433,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",
@@ -3107,15 +3527,29 @@
         },
         {
           "name": "first_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid first (given) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact first (given) name"
+          "title": "Close contact first (given) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "last_name",
-          "options": {},
+          "options": {
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a valid last (family) name"
+            }
+          },
           "type": "TextField",
-          "title": "Close contact last (family) name"
+          "title": "Close contact last (family) name",
+          "schema": {
+            "regex": "^[\\w'\\-,.][^0-9_!¡?÷?¿/\\+=@#$%^&*(){}|~<>;:[\\]]{2,}$"
+          }
         },
         {
           "name": "mWvTOY",
@@ -3156,7 +3590,13 @@
         },
         {
           "name": "mobile_number",
-          "options": { "required": false, "optionalText": false },
+          "options": {
+            "required": false,
+            "optionalText": false,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a mobile number in the correct format"
+            }
+          },
           "type": "TelephoneNumberField",
           "title": "Mobile number",
           "hint": "For example, 07700 900999",


### PR DESCRIPTION
- 'Contract' typo fixed
- Name fields exclude numbers and some punctuation symbols
- Mobile fields say mobile, not telephone, number in validation messages