### PR TITLE
feature: Changing the RAO form to capture test results more accurately 

### DIFF
--- a/runner/src/server/forms/ReportAnOutbreak.json
+++ b/runner/src/server/forms/ReportAnOutbreak.json
@@ -1,7 +1,7 @@
 {
   "metadata": {},
   "authentication": true,
-  "toggle": "false",
+  "toggle": "${magicLinkToggle}",
   "analytics": {
     "gtmId1": "GTM-MM6VPCXX"
   },

--- a/runner/src/server/forms/ReportAnOutbreak.json
+++ b/runner/src/server/forms/ReportAnOutbreak.json
@@ -2132,7 +2132,7 @@
           "name": "StaffSymptomsNotTested",
           "type": "NumberField",
           "title": "How many other staff have symptoms of an acute respiratory infection, including chest infections?",
-          "hint": "Include those who are currently in hospital<br>If none or you do not know, enter",
+          "hint": "Include those who are currently in hospital<br>If none or you do not know, enter 0",
           "options": {
             "required": true,
             "summaryTitle": "Staff: with symptoms, but not tested",
@@ -2437,7 +2437,7 @@
       "components": [
         {
           "type": "Para",
-          "content": "You do not have to test staff for COVID-19. Staff that are eligible for COVID-19 treatments should test themselves at home, if they have symptoms."
+          "content": "You do not have to test staff."
         },
         {
           "type": "NumberField",
@@ -2461,8 +2461,8 @@
         {
           "type": "NumberField",
           "name": "StaffSymptomsNotTested",
-          "title": "How many staff have symptoms of an acute respiratory infection, but have not been tested for any infection?",
-          "hint": "Include those who are currently in hospital<br>If none, enter 0",
+          "title": "How many other staff have symptoms of an acute respiratory infection, including chest infections?",
+          "hint": "Do not include cases that have been confirmed by a test as COVID-19<br>Include those who are currently in hospital<br>If none or you do not know, enter 0",
           "options": {
             "required": true,
             "summaryTitle": "Staff: with symptoms, but not tested",

--- a/runner/src/server/forms/ReportAnOutbreak.json
+++ b/runner/src/server/forms/ReportAnOutbreak.json
@@ -510,7 +510,7 @@
           },
           "options": {
             "summaryTitle": "Service users: negative COVID-19 test results",
-            "required": true,
+            "required": false,
             "customValidationMessages": {
               "number.max": "The number of service users that have been tested for COVID-19 and had a negative test result must be between 0 and 999",
               "number.min": "The number of service users that have been tested for COVID-19 and had a negative test result must be between 0 and 999"
@@ -1405,8 +1405,8 @@
         {
           "name": "ServiceUsersConfirmedARI",
           "type": "NumberField",
-          "title": "How many service users have symptoms of an acute respiratory infection, but have not been tested for any infection?",
-          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0",
+          "title": "How many service users have symptoms of an acute respiratory infection, including chest infections?",
+          "hint": "Include those who are currently in hospital or on visits out<br>If none or you do not know, enter 0",
           "schema": {
             "min": 0,
             "max": 999
@@ -1424,13 +1424,12 @@
           "name": "ServiceUsersTestedCovid",
           "type": "NumberField",
           "title": "How many service users have been tested for COVID-19 and had a negative test result?",
-          "hint": "If none, enter 0",
+          "hint": "If none or you do not know, enter 0",
           "schema": {
             "min": 0,
             "max": 999
           },
           "options": {
-            "required": false,
             "summaryTitle": "Service users: negative COVID-19 test results",
             "customValidationMessages": {
               "number.max": "The number of service users that have been tested for COVID-19 and had a negative test result must be between 0 and 999",
@@ -1442,7 +1441,7 @@
           "name": "ServiceUsersTestedFlu",
           "type": "NumberField",
           "title": "How many service users have been tested for flu and had a negative test result?",
-          "hint": "If none, enter 0",
+          "hint": "If none or you do not know, enter 0",
           "options": {
             "required": false,
             "summaryTitle": "Service users: negative flu test results",
@@ -1475,13 +1474,13 @@
       "components": [
         {
           "type": "Para",
-          "content": "You do not have to test staff for COVID-19. Staff that are eligible for COVID-19 treatments should test themselves at home, if they have symptoms."
+          "content": "You do not have to test your staff."
         },
         {
           "name": "StaffSymptomsNotTested",
           "type": "NumberField",
-          "title": "How many staff have symptoms of an acute respiratory infection, but have not been tested for any infection?",
-          "hint": "Include those who are currently in hospital<br>If none, enter 0",
+          "title": "How many staff have symptoms of an acute respiratory infection, including chest infections?",
+          "hint": "Include those who are currently in hospital<br>If none or you do not know, enter 0",
           "schema": {
             "min": 0,
             "max": 999
@@ -1499,14 +1498,13 @@
           "name": "StaffTestedCovid",
           "type": "NumberField",
           "title": "How many staff have been tested for COVID-19 and had a negative test result?",
-          "hint": "If none, enter 0",
+          "hint": "If none or you do not know, enter 0",
           "schema": {
             "min": 0,
             "max": 999
           },
           "options": {
             "summaryTitle": "Staff: negative COVID-19 test results",
-            "required": false,
             "customValidationMessages": {
               "number.max": "The number of staff that have been tested for COVID-19 and had a negative test result must be between 0 and 999",
               "number.min": "The number of staff that have been tested for COVID-19 and had a negative test result must be between 0 and 999"
@@ -1517,7 +1515,7 @@
           "name": "StaffTestedFlu",
           "type": "NumberField",
           "title": "How many staff have been tested for flu and had a negative test result?",
-          "hint": "If none, enter 0",
+          "hint": "If none or you do not know, enter 0",
           "options": {
             "required": false,
             "summaryTitle": "Staff: negative flu test results",
@@ -2385,7 +2383,7 @@
           "type": "NumberField",
           "name": "ServiceUsersCovidTestPositive",
           "title": "How many service users have COVID-19 confirmed by a positive test?",
-          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0",
+          "hint": "Include those who are currently in hospital or on visits out<br>If none or you do not know, enter 0",
           "options": {
             "required": true,
             "summaryTitle": "Service users: confirmed positive COVID-19 test results",
@@ -2443,7 +2441,7 @@
           "type": "NumberField",
           "name": "StaffCovidTestPositive",
           "title": "How many staff have COVID-19 confirmed by a positive test?",
-          "hint": "Include those who are currently in hospital<br>If none, enter 0",
+          "hint": "Include those who are currently in hospital<br>If none or you do not know, enter 0",
           "options": {
             "required": true,
             "summaryTitle": "Staff: confirmed positive COVID-19 test results",

--- a/runner/src/server/forms/ReportAnOutbreak.json
+++ b/runner/src/server/forms/ReportAnOutbreak.json
@@ -1,7 +1,7 @@
 {
   "metadata": {},
   "authentication": true,
-  "toggle": "${magicLinkToggle}",
+  "toggle": "false",
   "analytics": {
     "gtmId1": "GTM-MM6VPCXX"
   },
@@ -484,8 +484,8 @@
         {
           "name": "ServiceUsersSymptomsNotTested",
           "type": "NumberField",
-          "title": "How many service users have symptoms of an acute respiratory infection, but have not been tested for any infection?",
-          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0",
+          "title": "How many service users have symptoms of an acute respiratory infection, including chest infections?",
+          "hint": "Include those who are currently in hospital or on visits out<br>If none or you do not know, enter 0",
           "schema": {
             "min": 0,
             "max": 999
@@ -503,14 +503,14 @@
           "name": "ServiceUsersTestedCovid",
           "type": "NumberField",
           "title": "How many service users have been tested for COVID-19 and had a negative test result?",
-          "hint": "If none, enter 0",
+          "hint": "If none or you do not know, enter 0",
           "schema": {
             "min": 0,
             "max": 999
           },
           "options": {
             "summaryTitle": "Service users: negative COVID-19 test results",
-            "required": false,
+            "required": true,
             "customValidationMessages": {
               "number.max": "The number of service users that have been tested for COVID-19 and had a negative test result must be between 0 and 999",
               "number.min": "The number of service users that have been tested for COVID-19 and had a negative test result must be between 0 and 999"
@@ -521,7 +521,7 @@
           "name": "ServiceUsersTestedFlu",
           "type": "NumberField",
           "title": "How many service users have been tested for flu and had a negative test result?",
-          "hint": "If none, enter 0",
+          "hint": "If none or you do not know, enter 0",
           "options": {
             "required": false,
             "summaryTitle": "Service users: negative flu test results",
@@ -599,15 +599,19 @@
     },
     {
       "path": "/staff-ari-adenovirus",
-      "title": "Staff: number of adenovirus cases",
+      "title": "Staff: number of Adenovirus cases",
       "sectionForEndSummaryPages": "InfectionsInYourSetting",
       "disableSingleComponentAsHeading": true,
       "components": [
         {
+          "type": "Para",
+          "content": "You do not have to test your staff."
+        },
+        {
           "name": "StaffAdenovirus",
           "type": "NumberField",
           "title": "How many staff have tested positive for adenovirus?",
-          "hint": "Include those who are currently in hospital<br>If none, enter 0",
+          "hint": "Include those who are currently in hospital<br>If none or you do not know, enter 0",
           "schema": {
             "min": 0,
             "max": 999
@@ -727,7 +731,7 @@
           "name": "ServiceUsersHmpv",
           "type": "NumberField",
           "title": "How many service users have tested positive for human Metapneumovirus (hMPV)?",
-          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0",
+          "hint": "Include those who are currently in hospital or on visits out<br>If none or you do not know, enter 0",
           "schema": {
             "min": 0,
             "max": 999
@@ -821,7 +825,7 @@
           "name": "ServiceUsersHmpv",
           "type": "NumberField",
           "title": "How many service users have tested positive for human Metapneumovirus (hMPV)?",
-          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0",
+          "hint": "Include those who are currently in hospital or on visits out<br>If none or you do not know, enter 0",
           "schema": {
             "min": 0,
             "max": 999
@@ -1615,26 +1619,7 @@
           },
           "nameHasError": false,
           "title": "How many service users have flu confirmed by a positive swab test?",
-          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0"
-        },
-        {
-          "name": "ServiceUsersChestInfection",
-          "options": {
-            "required": false,
-            "summaryTitle": "Service users: diagnosed with a chest infection by a GP",
-            "customValidationMessages": {
-              "number.max": "The number of service users that have been diagnosed with a chest infection by a GP must be between 0 and 999",
-              "number.min": "The number of service users that have been diagnosed with a chest infection by a GP must be between 0 and 999"
-            }
-          },
-          "type": "NumberField",
-          "schema": {
-            "min": 0,
-            "max": 999
-          },
-          "nameHasError": false,
-          "title": "How many service users have been diagnosed with a chest infection by a GP?",
-          "hint": "Do not include cases that have been confirmed by a test as flu<br>Include those who are currently in hospital or on visits out<br>If none, enter 0"
+          "hint": "Include those who are currently in hospital or on visits out<br>If none or you do not know, enter 0"
         },
         {
           "name": "ServiceUsersSymptomsNotTested",
@@ -1652,8 +1637,8 @@
             "max": 999
           },
           "nameHasError": false,
-          "title": "How many service users have symptoms of an acute respiratory infection, but have not been tested for any infection?",
-          "hint": "Do not include cases that have been confirmed by a test as flu or diagnosed by a GP as a chest infection<br><br>Include those who are currently in hospital or on visits out<br>If none, enter 0"
+          "title": "How many other service users have symptoms of an acute respiratory infection, including chest infections?",
+          "hint": "Do not include cases that have been confirmed by a test as flu<br>Include those who are currently in hospital or on visits out<br>If none or you do not know, enter 0"
         },
         {
           "name": "ServiceUsersChestInfectionCovid19",
@@ -1672,7 +1657,7 @@
           },
           "nameHasError": false,
           "title": "How many service users have been tested for COVID-19 and had a negative test result?",
-          "hint": "If none, enter 0"
+          "hint": "If none or you do not know, enter 0"
         }
       ],
       "next": [
@@ -1692,7 +1677,7 @@
       "components": [
         {
           "type": "Para",
-          "content": "You do not have to test staff for COVID-19. Staff that are eligible for COVID-19 treatments should test themselves at home, if they have symptoms."
+          "content": "You do not have to test your staff."
         },
 
         {
@@ -1712,12 +1697,12 @@
           },
           "nameHasError": false,
           "title": "How many staff have flu confirmed by a positive swab test?",
-          "hint": "Include those who are currently in hospital<br>If none, enter 0"
+          "hint": "Include those who are currently in hospital<br>If none or you do not know, enter 0"
         },
         {
           "name": "StaffSymptomsNotTested",
           "options": {
-            "required": false,
+            "required": true,
             "summaryTitle": "Staff: with symptoms, but not tested",
             "customValidationMessages": {
               "number.max": "The number of staff that have symptoms of an acute respiratory infection, but have not been tested for any infection must be between 0 and 999",
@@ -1730,8 +1715,8 @@
             "max": 999
           },
           "nameHasError": false,
-          "title": "How many staff have symptoms of an acute respiratory infection, but have not been tested for any infection?",
-          "hint": "Include those who are currently in hospital<br>If none, enter 0"
+          "title": "How many other staff have symptoms of an acute respiratory infection, including chest infections?",
+          "hint": "Do not include cases that have been confirmed by a test as flu<br>Include those who are currently in hospital<br>If none or you do not know, enter 0"
         },
         {
           "name": "StaffChestInfectionCovid19",
@@ -1750,7 +1735,7 @@
           },
           "nameHasError": false,
           "title": "How many staff have been tested for COVID-19 and had a negative test result?",
-          "hint": "If none, enter 0"
+          "hint": "If none or you do not know, enter 0"
         }
       ],
       "next": [
@@ -2141,13 +2126,13 @@
       "components": [
         {
           "type": "Para",
-          "content": "You do not have to test staff for COVID-19. Staff that are eligible for COVID-19 treatments should test themselves at home, if they have symptoms."
+          "content": "You do not have to test your staff."
         },
         {
           "name": "StaffSymptomsNotTested",
           "type": "NumberField",
-          "title": "How many staff have symptoms of an acute respiratory infection, but have not been tested for any infection?",
-          "hint": "Include those who are currently in hospital<br>If none, enter 0",
+          "title": "How many other staff have symptoms of an acute respiratory infection, including chest infections?",
+          "hint": "Include those who are currently in hospital<br>If none or you do not know, enter",
           "options": {
             "required": true,
             "summaryTitle": "Staff: with symptoms, but not tested",
@@ -2166,7 +2151,7 @@
           "name": "OtherARIStaffTestedCovid",
           "type": "NumberField",
           "title": "How many staff have been tested for COVID-19 and had a negative test result?",
-          "hint": "If none, enter 0",
+          "hint": "If none or you do not know, enter 0",
           "options": {
             "required": false,
             "summaryTitle": "Staff: negative COVID-19 test results",
@@ -2184,7 +2169,7 @@
           "name": "OtherARIStaffTestedFlu",
           "type": "NumberField",
           "title": "How many staff have been tested for flu and had a negative test result?",
-          "hint": "If none, enter 0",
+          "hint": "If none or you do not know, enter 0",
           "options": {
             "required": false,
             "summaryTitle": "Staff: negative flu test results",
@@ -2418,8 +2403,8 @@
         {
           "type": "NumberField",
           "name": "ServiceUsersSymptomsNotTested",
-          "title": "How many service users have symptoms of an acute respiratory infection, but have not been tested for any infection?",
-          "hint": "Include those who are currently in hospital or on visits out<br>If none, enter 0",
+          "title": "How many other service users have symptoms of an acute respiratory infection, including chest infections?",
+          "hint": "Do not include cases that have been confirmed by a test as COVID-19<br>Include those who are currently in hospital or on visits out<br>If none or you do not know, enter 0",
           "options": {
             "required": true,
             "summaryTitle": "Service users: with symptoms, but not tested",


### PR DESCRIPTION
# Description

This change set has been carried our in order to capture test results more accurately.

## Context

The changes requested for form has been captured [here in Mural](https://app.mural.co/t/ukhsa1763/m/ukhsa1763/1746182112378/723e732cc0c7040ac441714dd140d90295eaef60)



## Changes

COVID SERVICE USERS:
<img width="687" height="510" alt="image" src="https://github.com/user-attachments/assets/9005ccde-ca93-40f8-a356-e938c3da9fd3" />



COVID STAFF
<img width="697" height="558" alt="image" src="https://github.com/user-attachments/assets/a38a7b5a-d8b5-4a6b-a3ca-1c21e8de2157" />


FLU SERVICE USERS
<img width="685" height="686" alt="image" src="https://github.com/user-attachments/assets/f19d48a3-733a-43d9-81fc-70cae162a2bc" />


FLU STAFF:
<img width="684" height="724" alt="image" src="https://github.com/user-attachments/assets/8913dad5-cfab-4ffb-9a7f-d483f4140a4f" />


KNOWN ARI SERVICE USERS
<img width="729" height="598" alt="image" src="https://github.com/user-attachments/assets/39548885-f329-4f52-9f62-2b4de6db2202" />
<img width="713" height="667" alt="image" src="https://github.com/user-attachments/assets/711d0f46-b4b1-4278-8b4f-84e80946ee7c" />


**OTHER ARI KNOWN PATHWAY STAFF**

<img width="704" height="635" alt="image" src="https://github.com/user-attachments/assets/784e0cbc-6b17-400a-9d83-a7edb36b78b0" />

<img width="654" height="810" alt="image" src="https://github.com/user-attachments/assets/9fd430c3-e61e-4995-b7e5-f79acf9dc251" />

STAFF ARI UNKNOWN:
<img width="646" height="753" alt="image" src="https://github.com/user-attachments/assets/19979f40-e7ab-4321-99e3-622c5c6acbc0" />

SERVICEUSERS UNKNOWN:
<img width="636" height="739" alt="image" src="https://github.com/user-attachments/assets/0099c81c-0c52-4467-a514-f1aebf1b531f" />


## Type of change

What is the type of change you are making?

- [ ] Chore or documentation (non-breaking change that does not add functionality)
- [ ] ADR (Architectural Decision Record, non-breaking change that documents or proposes a decision)
- [ ] Refactor (non-breaking change that improves code quality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Changing form cosmetics (Changing wording or order of questions) 


Have you updated the PR title to match the type of change you are making?

- [X] Yes
- [ ] No, I need help or guidance

# Testing

<!--
Several departments use XGovFormBuilder in production.
Automated tests help ensure that changes do not break existing functionality for another department.

Maintainers are sympathetic to the time constraints of government departments, but please try to be good citizens and add tests when possible.
-->

## Automated tests

Have you added automated tests?

- [ ] Yes, unit or integration tests
- [ ] Yes, end-to-end (cypress) tests
- [ ] No, tests are not required for this change
- [ ] No, I need help or guidance
- [X] No, these are content changes.
- 
## Manual tests

Have you manually tested your changes?

- [X] Yes - Went through the journeys submitted form, confirmed the submission was available in saleforce
- [ ] No, manual tests are not required or sufficiently covered by automated tests

Have you attached an example form JSON or snippet for the reviewer in this PR?

- [X] Yes
- [ ] No, any existing form can be used
- [ ] No, it is not required or not applicable

### Steps to test
There are journeys listed [here](https://app.mural.co/t/ukhsa1763/m/ukhsa1763/1746182112378/723e732cc0c7040ac441714dd140d90295eaef60)  go through them and submit the form.

# Documentation

Have you updated the documentation?

- [ ] Yes, I have updated [./docs](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs) for this change since additional explanation or steps to use/configure the feature is required
- [ ] Yes, I have added or updated an [ADR](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs/adr) for this change since it is large, complex, or has significant architectural implications
- [ ] Yes, I have added inline comments for hard-to-understand areas
- [ ] No, I am not sure if documentation is required
- [X] No, documentation is not required for this change

# Discussion

> [!WARNING]
>
> Large or complex changes may require discussion with the maintainers before they can be merged. If it has not yet been discussed, it may delay the review process

Have you discussed this change with the maintainers?

- [ ] Yes, I have discussed this change with the maintainers on slack, email or via GitHub issues
- [ ] Yes, this change is an ADR to help kick-off discussion
- [ ] No, this change is small and does not require discussion
- [X] No, I am not sure if one is required
