### PR TITLE
FORM CHANGE - referencing section name

### DIFF
--- a/runner/src/server/forms/kls-training-request.json
+++ b/runner/src/server/forms/kls-training-request.json
@@ -1089,7 +1089,7 @@
     }
   ],
   "version": 2,
-  "skipSummary": false,
+  "skipSummary": true,
   "feeOptions": {
     "allowSubmissionWithoutPayment": true,
     "maxAttempts": 3,

--- a/runner/src/server/forms/kls-training-request.json
+++ b/runner/src/server/forms/kls-training-request.json
@@ -17,7 +17,6 @@
     {
       "title": "Request training from Knowledge and Library Services",
       "path": "/start",
-      "section": "startPage",
       "components": [
         {
           "name": "mainContent",
@@ -988,7 +987,7 @@
         "conditions": [
           {
             "field": {
-              "name": "BpuPgW",
+              "name": "trainingPart2.BpuPgW",
               "type": "RadiosField",
               "display": "Which organisation do you belong to?"
             },
@@ -1010,7 +1009,7 @@
         "conditions": [
           {
             "field": {
-              "name": "BpuPgW",
+              "name": "trainingPart2.BpuPgW",
               "type": "RadiosField",
               "display": "Which organisation do you belong to?"
             },


### PR DESCRIPTION
# Description
- When writing conditions sections should be correctly referenced
- Added two line change to reference Training from path condition working this fixes the problem with the paths not working -- paths have now been correctly re-named functioning correctly and the code is more easily readable
- Added skip summary page
