### PR TITLE
Feature - Added Subtitile to mini summary page controller 

### DIFF
--- a/runner/src/server/forms/kls-training-request.json
+++ b/runner/src/server/forms/kls-training-request.json
@@ -179,6 +179,7 @@
       "title": "Confirm the information below",
       "section": "trainingPart1",
       "options": {
+        "subtitle": "You will not be able to change your answers later once confirmed.",
         "multiSummary": true,
         "content": "Please check your details and click the 'Submit' button.",
         "sections": ["trainingPart1"],

--- a/runner/src/server/forms/kls-training-request.json
+++ b/runner/src/server/forms/kls-training-request.json
@@ -94,7 +94,7 @@
     },
     {
       "path": "/training-request-part-1",
-      "section": "trainingPart1",
+      "section": "trainingQuestions",
       "title": "Training request part 1",
       "disableBackLink": true,
       "components": [
@@ -169,42 +169,13 @@
       ],
       "next": [
         {
-          "path": "/training-details-summary"
+          "path": "/training-request-part-2"
         }
       ]
     },
     {
-      "path": "/training-details-summary",
-      "controller": "MiniSummaryPageController",
-      "title": "Confirm the information below",
-      "section": "trainingPart1",
-      "options": {
-        "multiSummary": true,
-        "content": "Please check your details and click the 'Submit' button.",
-        "sections": ["trainingPart1"],
-        "customText": {
-          "title": "Check your answers"
-        }
-      },
-      "next": [{ "path": "/training-request-part-2" }]
-    },
-    {
-      "title": "Enquiry summary",
-      "path": "/summary",
-      "controller": "./pages/summary.js",
-      "components": [
-        {
-          "name": "PdoDpO",
-          "options": {},
-          "type": "Para",
-          "content": "Please check your details and click the 'Submit' button."
-        }
-      ],
-      "next": []
-    },
-    {
       "path": "/training-request-part-2",
-      "section": "trainingPart2",
+      "section": "trainingQuestions",
       "title": "Training request part 2",
       "components": [
         {
@@ -282,7 +253,7 @@
       "path": "/training-topics-summary",
       "controller": "MiniSummaryPageController",
       "title": "Confirm the information below",
-      "section": "trainingPart2",
+      "section": "trainingQuestions",
       "options": {
         "content": "Please check your details and click the 'Submit' button.",
         "customText": {
@@ -613,6 +584,20 @@
           "path": "/summary"
         }
       ]
+    },
+    {
+      "title": "Enquiry summary",
+      "path": "/summary",
+      "controller": "./pages/summary.js",
+      "components": [
+        {
+          "name": "PdoDpO",
+          "options": {},
+          "type": "Para",
+          "content": "Please check your details and click the 'Submit' button."
+        }
+      ],
+      "next": []
     }
   ],
   "lists": [
@@ -953,13 +938,8 @@
   ],
   "sections": [
     {
-      "name": "trainingPart1",
+      "name": "trainingQuestions",
       "title": "Training Details",
-      "hideTitle": true
-    },
-    {
-      "name": "trainingPart2",
-      "title": "Training Topics",
       "hideTitle": true
     },
     {
@@ -987,7 +967,7 @@
         "conditions": [
           {
             "field": {
-              "name": "trainingPart2.BpuPgW",
+              "name": "trainingQuestions.BpuPgW",
               "type": "RadiosField",
               "display": "Which organisation do you belong to?"
             },
@@ -1009,7 +989,7 @@
         "conditions": [
           {
             "field": {
-              "name": "trainingPart2.BpuPgW",
+              "name": "trainingQuestions.BpuPgW",
               "type": "RadiosField",
               "display": "Which organisation do you belong to?"
             },

--- a/runner/src/server/plugins/engine/pageControllers/MiniSummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/MiniSummaryPageController.ts
@@ -7,14 +7,22 @@ import { PageController } from "./PageController";
  */
 export class MiniSummaryPageController extends PageController {
   isMiniSummaryPageController = true;
+  subtitle?: string;
 
   makeGetRouteHandler() {
     return async (request: HapiRequest, h: HapiResponseToolkit) => {
       const { cacheService } = request.services([]);
       const state = await cacheService.getState(request);
-      const { title, model } = this;
+      const { title, subtitle, model } = this;
 
-      const summary = new SummaryViewModel(title, model, state, request);
+      // TODO: add subtitile to be use in summary view
+      const summary = new SummaryViewModel(
+        title,
+        subtitle,
+        model,
+        state,
+        request
+      );
       const sectionDetails = this.pageDef.section
         ? summary.details.find((detail) => detail.name === this.pageDef.section)
         : summary.details[0];

--- a/runner/src/server/plugins/engine/pageControllers/MiniSummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/MiniSummaryPageController.ts
@@ -9,20 +9,18 @@ export class MiniSummaryPageController extends PageController {
   isMiniSummaryPageController = true;
   subtitle?: string;
 
+  constructor(model, pageDef) {
+    super(model, pageDef);
+    this.subtitle = pageDef.options?.subtitle;
+  }
+
   makeGetRouteHandler() {
     return async (request: HapiRequest, h: HapiResponseToolkit) => {
       const { cacheService } = request.services([]);
       const state = await cacheService.getState(request);
       const { title, subtitle, model } = this;
 
-      // TODO: add subtitile to be use in summary view
-      const summary = new SummaryViewModel(
-        title,
-        subtitle,
-        model,
-        state,
-        request
-      );
+      const summary = new SummaryViewModel(title, model, state, request);
       const sectionDetails = this.pageDef.section
         ? summary.details.find((detail) => detail.name === this.pageDef.section)
         : summary.details[0];

--- a/runner/src/server/plugins/engine/pageControllers/MiniSummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/MiniSummaryPageController.ts
@@ -18,7 +18,7 @@ export class MiniSummaryPageController extends PageController {
     return async (request: HapiRequest, h: HapiResponseToolkit) => {
       const { cacheService } = request.services([]);
       const state = await cacheService.getState(request);
-      const { title, subtitle, model } = this;
+      const { title, model } = this;
 
       const summary = new SummaryViewModel(title, model, state, request);
       const sectionDetails = this.pageDef.section

--- a/runner/src/server/plugins/engine/views/partials/heading.html
+++ b/runner/src/server/plugins/engine/views/partials/heading.html
@@ -6,3 +6,6 @@
     {{pageTitle}}
   </h1>
 {% endif %}
+{% if page.subtitle %}
+    <p class="govuk-hint">{{ page.subtitle }}</p>
+{% endif %}


### PR DESCRIPTION
## Description
The mini summary page controller required a subtitle field to allow content to be displayed above the summary list. Without this, there was no way to add contextual text between the page title and the summary list items without hardcoding it in the template.

NOTE: The reason I decided to add subtitle to `MiniSummaryPageController` (Child class) instead of Inheriting it form its parent class `PageController` is because I believe most other forms have subtitle added using some sort of component and as explained above this is not possible in `MiniSummaryPageController`.
So I didn't want to make it something generic to all pages as otherwise it would cause confusion and contrast with the way subtitles are currently set in the rest of the forms

NOTE: The other sort of opinioneted change I made is to add the subtitle to the options tab as opposed to the generic PageDef schema 
I thought this through and the reason I decided to go with this option in because It follows the current standard of how Page specific variables are passed into Pages that need things that are not comunal to the generic page 

the disadvantage of this is that the schema is not clearly defined for specific pages - but this is not done anywhere across the repo -- I suggest getting this sorted for all page components but this is a tech debt task that in my opinion goes way beyond the scope of this pr 

## Changes
- Added `subtitle?: string` property declaration to `MiniSummaryPageController`
- Read `subtitle` from `pageDef` in the constructor so it can be configured via the form JSON definition
- Updated `heading.html` to render the subtitle above the confirm button when `page.subtitle` is set
- Moved Enquiry summary to the end of the `kls-training-request` form so the path strucuture is ordered
- Changed the two section pages to be part of the same section for better logic and properly displaying mid point summary



## Discussion: Where should `MiniSummaryPageController` types live?

The property was declared inline on the class to stay consistent with the existing pattern in `PageControllerBase`. However this isn't ideal — as seen elsewhere in the codebase (e.g. components), types are cleanly separated into `types.ts` files.

Some options worth discussing:

**Option 1 — Dedicated `types.ts` for page controllers** (mirrors the components pattern)
```typescript
// pageControllers/types.ts
export interface MiniSummaryPageDef extends PageDef {
  subtitle?: string;
}
```

**Option 2 — Type the `pageDef` parameter properly across all controllers**
Currently `pageDef` is typed as `{ [prop: string]: any }` everywhere which means any property can be passed in unchecked. Defining proper `pageDef` interfaces per controller would catch misconfigurations at the form definition level.

**Option 3 — Keep inline but audit `PageControllerBase`**
If the broader pattern isn't going to change, at minimum `PageControllerBase` properties could be extracted into an interface it `implements`, making the inheritance chain self-documenting.

Given that components already use `types.ts`, Option 1 seems the most consistent with the direction the codebase is heading.

## Type of change

What is the type of change you are making?

- [ ] Chore or documentation (non-breaking change that does not add functionality)
- [ ] ADR (Architectural Decision Record, non-breaking change that documents or proposes a decision)
- [ ] Refactor (non-breaking change that improves code quality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### PR title

PR titles should be prefixed with the type of change you are making, based on the [README.md#versioning](https://github.com/XGovFormBuilder/digital-form-builder?tab=readme-ov-file#versioning).
This is so that when performing a squash merge, the PR title is automatically used as the commit message.

Have you updated the PR title to match the type of change you are making?

- [x] Yes
- [ ] No, I need help or guidance

# Testing

## Automated tests

Have you added automated tests?

- [ ] Yes, unit or integration tests
- [ ] Yes, end-to-end (cypress) tests
- [ ] No, tests are not required for this change
- [ ] No, I need help or guidance
- [x] No (explain why tests are not required or can't be added at this time)

## Manual tests

Have you manually tested your changes?

- [ ] Yes
- [x] No, manual tests are not required or sufficiently covered by automated tests

Have you attached an example form JSON or snippet for the reviewer in this PR?

- [ ] Yes
- [ ] No, any existing form can be used
- [ ] No, it is not required or not applicable

### Steps to test

1. Step 1
2. Step 2

# Documentation

Have you updated the documentation?

- [ ] Yes, I have updated [./docs](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs) for this change since additional explanation or steps to use/configure the feature is required
- [ ] Yes, I have added or updated an [ADR](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs/adr) for this change since it is large, complex, or has significant architectural implications
- [ ] Yes, I have added inline comments for hard-to-understand areas
- [ ] No, I am not sure if documentation is required
- [ ] No, documentation is not required for this change

# Discussion

Have you discussed this change with the maintainers?
- [x] Yes, I have discussed this change with the maintainers on slack, email or via GitHub issues
- [ ] Yes, this change is an ADR to help kick-off discussion
- [ ] No, this change is small and does not require discussion
- [ ] No, I am not sure if one is required
