### PR TITLE
Feature - Improved extensibility and design of the Next button text + allow X-Gov users to set custom text

### DIFF
--- a/model/src/schema/schema.ts
+++ b/model/src/schema/schema.ts
@@ -126,6 +126,7 @@ const pageSchema = joi.object().keys({
   options: joi.object().optional(),
   backLinkFallback: joi.string().optional(),
   disableBackLink: joi.bool().optional(),
+  customButtonText: joi.string().default("Continue"),
 });
 
 const startNavigationLinkSchema = joi.object().keys({

--- a/model/src/schema/schema.ts
+++ b/model/src/schema/schema.ts
@@ -126,7 +126,7 @@ const pageSchema = joi.object().keys({
   options: joi.object().optional(),
   backLinkFallback: joi.string().optional(),
   disableBackLink: joi.bool().optional(),
-  customButtonText: joi.string().default("Continue"),
+  customButtonText: joi.string().optional(),
 });
 
 const startNavigationLinkSchema = joi.object().keys({

--- a/runner/src/server/forms/kls-training-request.json
+++ b/runner/src/server/forms/kls-training-request.json
@@ -393,6 +393,7 @@
     {
       "path": "/about-you-uksa-summary",
       "controller": "MiniSummaryPageController",
+      "customButtonText": "Submit",
       "title": "Confirm the information before submitting",
       "section": "aboutYouUKHSA",
       "options": {
@@ -491,6 +492,7 @@
       "controller": "MiniSummaryPageController",
       "title": "Confirm the information before submitting",
       "section": "aboutYouLAPH",
+      "customButtonText": "Submit",
       "options": {
         "content": "Please check your details and click the 'Submit' button.",
         "customText": {
@@ -571,6 +573,7 @@
     },
     {
       "path": "/about-you-summary",
+      "customButtonText": "Submit",
       "controller": "MiniSummaryPageController",
       "title": "Confirm the information before submitting",
       "section": "aboutYou",

--- a/runner/src/server/plugins/engine/pageControllers/MiniSummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/MiniSummaryPageController.ts
@@ -38,4 +38,8 @@ export class MiniSummaryPageController extends PageController {
   get viewName() {
     return "mini-summary";
   }
+
+  get defaultButtonText() {
+    return "Confirm and continue";
+  }
 }

--- a/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -67,7 +67,7 @@ export class PageControllerBase {
   details?: any;
   disableBackLink?: boolean;
   returnUrl?: string;
-  customButtonText?: string;
+  buttonText?: string;
 
   // TODO: pageDef type
   constructor(model: FormModel, pageDef: { [prop: string]: any } = {}) {
@@ -87,8 +87,7 @@ export class PageControllerBase {
     this.disableBackLink = pageDef.disableBackLink;
     this.disableSingleComponentAsHeading =
       pageDef.disableSingleComponentAsHeading;
-    this.customButtonText =
-      pageDef.options?.customButtonText ?? this.defaultButtonText;
+    this.buttonText = pageDef.customButtonText ?? this.defaultButtonText;
 
     // Resolve section
     this.section = model.sections?.find(

--- a/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -67,6 +67,7 @@ export class PageControllerBase {
   details?: any;
   disableBackLink?: boolean;
   returnUrl?: string;
+  customButtonText?: string;
 
   // TODO: pageDef type
   constructor(model: FormModel, pageDef: { [prop: string]: any } = {}) {
@@ -86,6 +87,8 @@ export class PageControllerBase {
     this.disableBackLink = pageDef.disableBackLink;
     this.disableSingleComponentAsHeading =
       pageDef.disableSingleComponentAsHeading;
+    this.customButtonText =
+      pageDef.options?.customButtonText ?? this.defaultButtonText;
 
     // Resolve section
     this.section = model.sections?.find(
@@ -216,6 +219,10 @@ export class PageControllerBase {
    */
   get hasNext() {
     return Array.isArray(this.pageDef.next) && this.pageDef.next.length > 0;
+  }
+
+  get defaultButtonText() {
+    return "Continue";
   }
 
   get next() {

--- a/runner/src/server/plugins/engine/pageControllers/StartPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/StartPageController.ts
@@ -15,4 +15,8 @@ export class StartPageController extends PageController {
       skipTimeoutWarning: true,
     };
   }
+
+  get defaultButtonText() {
+    return "Start now";
+  }
 }

--- a/runner/src/server/plugins/engine/views/partials/form.html
+++ b/runner/src/server/plugins/engine/views/partials/form.html
@@ -18,10 +18,10 @@
   {% if not (components[0].type == "FlashCard") %}
     {% if page.isRepeatingFieldPageController and page.isSamePageDisplayMode %}
     {% if details.rows.length %}
-    {{ govukButton({ attributes: { id: "submit" }, text: page.options.customButtonText if page.options.customButtonText else "Continue", name: "next", value: "continue"}) }}
+    {{ govukButton({ attributes: { id: "submit" }, text: page.buttonText if page.buttonText else "Continue", name: "next", value: "continue"}) }}
     {% endif %}
     {% else %}
-    {{ govukButton({ attributes: { id: "submit" }, text: page.options.customButtonText if page.options.customButtonText else "Continue" }) }}
+    {{ govukButton({ attributes: { id: "submit" }, text: page.buttonText if page.buttonText else "Continue" }) }}
     {% if allowExit %}
       <button class="govuk-body govuk-button--link govuk-!-display-block" data-module="govuk-button" name="action" value="exit">
         Save and come back later

--- a/runner/src/server/plugins/engine/views/partials/form.html
+++ b/runner/src/server/plugins/engine/views/partials/form.html
@@ -16,23 +16,17 @@
   {% endif %}
 
   {% if not (components[0].type == "FlashCard") %}
-    {% if isStartPage %}
-      {{ govukButton({ attributes: { id: "submit" }, text: "Start now", isStartButton: true }) }}
-    {% elseif page.isMiniSummaryPageController %}
-      {{ govukButton({ attributes: { id: "submit" }, text: "Confirm and continue" }) }}
+    {% if page.isRepeatingFieldPageController and page.isSamePageDisplayMode %}
+    {% if details.rows.length %}
+    {{ govukButton({ attributes: { id: "submit" }, text: page.options.customButtonText if page.options.customButtonText else "Continue", name: "next", value: "continue"}) }}
+    {% endif %}
     {% else %}
-      {% if page.isRepeatingFieldPageController and page.isSamePageDisplayMode %}
-        {% if details.rows.length %}
-          {{ govukButton({ attributes: { id: "submit" }, text: "Continue", name: "next", value: "continue"}) }}
-        {% endif %}
-      {% else %}
-        {{ govukButton({ attributes: { id: "submit" }, text: "Continue" }) }}
-        {% if allowExit %}
-          <button class="govuk-body govuk-button--link govuk-!-display-block" data-module="govuk-button" name="action" value="exit">
-            Save and come back later
-          </button>
+    {{ govukButton({ attributes: { id: "submit" }, text: page.options.customButtonText if page.options.customButtonText else "Continue" }) }}
+    {% if allowExit %}
+      <button class="govuk-body govuk-button--link govuk-!-display-block" data-module="govuk-button" name="action" value="exit">
+        Save and come back later
+      </button>
 
-        {% endif %}
       {% endif %}
     {% endif %}
   {% endif %}


### PR DESCRIPTION
# Description
## Context
The mini summary page required a custom button text that differed from the default "Continue". Previously there was no way to configure this without either hardcoding it in the template or modifying the controller directly — neither of which is a good solution for content that may need to vary per form instance.

This exposed a broader design problem: button text was hardcoded in the template using a series of `if/elseif` statements to handle different page types:

```njk
{% if isStartPage %}
  {{ govukButton({ text: "Start now" }) }}
{% elseif page.isMiniSummaryPageController %}
  {{ govukButton({ text: "Confirm and continue" }) }}
{% else %}
  {{ govukButton({ text: "Continue" }) }}
{% endif %}
```

This pattern was brittle — every time a new controller type needed a different button text, the template had to be modified. The template was accumulating knowledge about controller types that it shouldn't need to know about.

## Changes
- Added custom button text to schema - `customButtonText: joi.string().optional(),`
- Added `defaultButtonText` getter to `PageControllerBase` returning `"Continue"`
- Added `defaultButtonText` to child classes `miniSummaryPageController` and `SummaryPageController` in line with what was detailed in the previous if/else
- Each controller subclass overrides `defaultButtonText` with its own appropriate default
- Added `customButtonText` to `PageOptions` interface allowing per-page-instance overrides via `pageDe.customButtonText` (see the great advantage of this functionlity belo)
- Parent constructor resolves final value via `pageDef.customButtonText ?? this.defaultButtonText`
- Template simplified to a single line: `{{ govukButton({ text: page.customButtonText }) }}`
- No long hard to read if/else statment -- cler maintainable and extendable logic

## Why this is better
The immediate need was to allow the mini summary page to display a specific button text without hardcoding it. Rather than adding yet another `if` statement to the template, this PR takes the opportunity to fix the underlying design problem.

The template no longer needs to know about controller types — that logic now lives where it belongs, in the controllers themselves. Adding a new controller with a different default button text requires no template changes at all, just overriding the getter. The pattern also allows per-instance overrides via the form JSON without any code changes, making it more flexible for content editors.

> An added advantage of this approach is that by making pages more easily customisable via configuration, users are less likely to resort to creating entirely new custom page controllers for minor variations in behaviour — reducing the accumulation of controller sprawl and keeping technical debt in check.

## Changes

- Change A
- Change B

## Type of change

What is the type of change you are making?

- [ ] Chore or documentation (non-breaking change that does not add functionality)
- [ ] ADR (Architectural Decision Record, non-breaking change that documents or proposes a decision)
- [x] Refactor (non-breaking change that improves code quality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### PR title

PR titles should be prefixed with the type of change you are making, based on the [README.md#versioning](https://github.com/XGovFormBuilder/digital-form-builder?tab=readme-ov-file#versioning).
This is so that when performing a squash merge, the PR title is automatically used as the commit message.

Have you updated the PR title to match the type of change you are making?

- [ ] Yes
- [ ] No, I need help or guidance

# Testing

<!--
Several departments use XGovFormBuilder in production.
Automated tests help ensure that changes do not break existing functionality for another department.

Maintainers are sympathetic to the time constraints of government departments, but please try to be good citizens and add tests when possible.
-->

## Automated tests

Have you added automated tests?

- [ ] Yes, unit or integration tests
- [x] Yes, end-to-end (cypress) tests
- [ ] No, tests are not required for this change
- [ ] No, I need help or guidance
- [ ] No (explain why tests are not required or can't be added at this time)

## Manual tests

Have you manually tested your changes?

- [x] Yes
- [ ] No, manual tests are not required or sufficiently covered by automated tests

Have you attached an example form JSON or snippet for the reviewer in this PR?

- [x] Yes
- [ ] No, any existing form can be used
- [ ] No, it is not required or not applicable

### Steps to test

<!--
Only fill out this section if you answered "Yes" to manually testing your changes.

In this section
- describe the tests that you ran to verify your changes
- provide instructions and a form JSON or snippet so we can reproduce the test if necessary

If uploading a form JSON, use the "attach files" feature in GitHub PR.
-->

1. Step 1
2. Step 2

# Documentation

Have you updated the documentation?

- [ ] Yes, I have updated [./docs](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs) for this change since additional explanation or steps to use/configure the feature is required
- [x] Yes, I have added or updated an [ADR](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs/adr) for this change since it is large, complex, or has significant architectural implications
- [ ] Yes, I have added inline comments for hard-to-understand areas
- [ ] No, I am not sure if documentation is required
- [ ] No, documentation is not required for this change

# Discussion

> [!WARNING]
>
> Large or complex changes may require discussion with the maintainers before they can be merged. If it has not yet been discussed, it may delay the review process

Have you discussed this change with the maintainers?

- [ ] Yes, I have discussed this change with the maintainers on slack, email or via GitHub issues
- [ ] Yes, this change is an ADR to help kick-off discussion
- [ ] No, this change is small and does not require discussion
- [ ] No, I am not sure if one is required
