### PR TITLE
Micol/mega form change button resolution

### DIFF
--- a/docs/adr/0008-custom-button-text.md
+++ b/docs/adr/0008-custom-button-text.md
@@ -1,0 +1,78 @@
+# ADR-0008: Configurable Button Text via Controller Getter Pattern
+
+**Status:** Accepted  
+**Date:** 2025-03-04
+
+## Context
+
+Button text in the page template was controlled by a growing if/elseif chain that required the template to know about controller types. There was also no way to customise button text per page instance without changing code.
+
+## Decision
+
+Replace the template conditional with a `defaultButtonText` getter on `PageControllerBase`. Subclasses override the getter with their own default. An optional `customButtonText` field in the page definition allows per-instance overrides without any code changes.
+
+```njk
+{{/* Before */}}
+{% if isStartPage %}
+  {{ govukButton({ text: "Start now" }) }}
+{% elseif page.isMiniSummaryPageController %}
+  {{ govukButton({ text: "Confirm and continue" }) }}
+{% else %}
+  {{ govukButton({ text: "Continue" }) }}
+{% endif %}
+
+{{/* After */}}
+{{ govukButton({ text: page.buttonText }) }}
+```
+
+Resolution order in the base constructor:
+
+```js
+this.buttonText = pageDef.customButtonText ?? this.defaultButtonText;
+```
+
+## Consequences
+
+- Template no longer needs to know about controller types
+- New controllers override the getter only — no template changes needed
+- Per-instance text is configurable via form JSON — no code changes needed
+- Reduces incentive to create new controllers for minor UI variations
+- Fully backwards compatible — existing pages are unaffected
+
+---
+
+# ADR-0008: Subtitle Field on MiniSummaryPageController
+
+**Status:** Accepted  
+**Date:** 2025-03-04
+
+## Context
+
+The mini summary page had no way to display contextual text between the page title and the summary list. The only option was to hardcode it in the template. A configurable `subtitle` field was needed.
+
+## Decision
+
+Add `subtitle?: string` to `MiniSummaryPageController` only, not to the shared `PageControllerBase`. The value is read from `pageDef` in the constructor and rendered in `heading.html` when present.
+
+```js
+// MiniSummaryPageController constructor
+this.subtitle = pageDef.options?.subtitle;
+```
+
+```html
+{% if page.subtitle %}
+<p class="govuk-body">{{ page.subtitle }}</p>
+{% endif %}
+```
+
+**Why not on the base class?** Most pages set subtitles via a component. Putting it on the base would conflict with that pattern and cause confusion. Keeping it scoped to `MiniSummaryPageController` reflects that this is a workaround specific to a controller that cannot use the standard component approach.
+
+**Why `options` rather than the top-level `pageDef` schema?** This follows the existing convention for passing page-specific variables — properties that aren't communal to all pages go through `options`. The trade-off is that `options` is not schema-validated per page type, which is an acknowledged gap across the codebase (see tech debt note below).
+
+## Consequences
+
+- Subtitle can be configured per page instance via form JSON — no code changes needed
+- Scoped to `MiniSummaryPageController` only — no risk of conflicting with subtitle handling on other page types
+- Fully backwards compatible — pages without a `subtitle` in their definition are unaffected
+
+**Tech debt:** The `options` object is untyped across the repo, meaning misconfigured properties fail silently at runtime rather than being caught at load time. A follow-up task should define typed `pageDef` interfaces per controller (e.g. a dedicated `pageControllers/types.ts` mirroring the components pattern) and validate them at startup. This is out of scope for this PR.

--- a/docs/adr/0009-mini-summary-page-subtitle.md
+++ b/docs/adr/0009-mini-summary-page-subtitle.md
@@ -1,0 +1,37 @@
+---
+
+# ADR-0008: Subtitle Field on MiniSummaryPageController
+
+**Status:** Accepted  
+**Date:** 2025-03-04
+
+## Context
+
+The mini summary page had no way to display contextual text between the page title and the summary list. The only option was to hardcode it in the template. A configurable `subtitle` field was needed.
+
+## Decision
+
+Add `subtitle?: string` to `MiniSummaryPageController` only, not to the shared `PageControllerBase`. The value is read from `pageDef` in the constructor and rendered in `heading.html` when present.
+
+```js
+// MiniSummaryPageController constructor
+this.subtitle = pageDef.options?.subtitle;
+```
+
+```html
+{% if page.subtitle %}
+<p class="govuk-body">{{ page.subtitle }}</p>
+{% endif %}
+```
+
+**Why not on the base class?** Most pages set subtitles via a component. Putting it on the base would conflict with that pattern and cause confusion. Keeping it scoped to `MiniSummaryPageController` reflects that this is a workaround specific to a controller that cannot use the standard component approach.
+
+**Why `options` rather than the top-level `pageDef` schema?** This follows the existing convention for passing page-specific variables — properties that aren't communal to all pages go through `options`. The trade-off is that `options` is not schema-validated per page type, which is an acknowledged gap across the codebase (see tech debt note below).
+
+## Consequences
+
+- Subtitle can be configured per page instance via form JSON — no code changes needed
+- Scoped to `MiniSummaryPageController` only — no risk of conflicting with subtitle handling on other page types
+- Fully backwards compatible — pages without a `subtitle` in their definition are unaffected
+
+**Tech debt:** The `options` object is untyped across the repo, meaning misconfigured properties fail silently at runtime rather than being caught at load time. A follow-up task should define typed `pageDef` interfaces per controller (e.g. a dedicated `pageControllers/types.ts` mirroring the components pattern) and validate them at startup. This is out of scope for this PR.

--- a/runner/src/server/forms/kls-enquiries.json
+++ b/runner/src/server/forms/kls-enquiries.json
@@ -164,6 +164,7 @@
     },
     {
       "path": "/type-of-enquiry",
+      "section": "typeOfEnquiry",
       "title": "Type of enquiry",
       "components": [
         {
@@ -182,7 +183,7 @@
               "any.only": "Select the option that best matches your enquiry",
               "string.empty": "Select the option that best matches your enquiry"
             },
-            "disableChangingFromSummary": true,
+            "disableChangingFromSummary": false,
             "exposeToContext": false
           },
           "type": "RadiosField",
@@ -194,6 +195,25 @@
           "schema": {}
         }
       ],
+      "next": [
+        {
+          "path": "/type-of-enquiry-summary"
+        }
+      ]
+    },
+    {
+      "path": "/type-of-enquiry-summary",
+      "section": "typeOfEnquiry",
+      "controller": "MiniSummaryPageController",
+      "title": "Confirm the information before submitting",
+      "customButtonText": "Confirm and Continue",
+      "subtitle": "You will not be able to change your answer later once confirmed.",
+      "options": {
+        "content": "Please check your details and click the 'Submit' button.",
+        "customText": {
+          "title": "Check your answers"
+        }
+      },
       "next": [
         {
           "path": "/current-awareness",
@@ -876,6 +896,7 @@
     {
       "path": "/which-organisation-do-you-work-for-validated",
       "title": "Which organisation do you work for?",
+      "section": "whichOrganisationValidated",
       "disableBackLink": true,
       "components": [
         {
@@ -886,7 +907,7 @@
               "any.only": "Select the organisation you work for",
               "string.empty": "Select the organisation you work for"
             },
-            "disableChangingFromSummary": true
+            "disableChangingFromSummary": false
           },
           "type": "RadiosField",
           "title": "Which organisation do you work for?",
@@ -898,6 +919,25 @@
           }
         }
       ],
+      "next": [
+        {
+          "path": "/which-organisation-do-you-work-for-summary"
+        }
+      ]
+    },
+    {
+      "path": "/which-organisation-do-you-work-for-summary",
+      "section": "whichOrganisationValidated",
+      "controller": "MiniSummaryPageController",
+      "title": "Confirm the information before submitting",
+      "customButtonText": "Confirm and Continue",
+      "subtitle": "You will not be able to change your answer later once confirmed.",
+      "options": {
+        "content": "Please check your details and click the 'Submit' button.",
+        "customText": {
+          "title": "Check your answers"
+        }
+      },
       "next": [
         {
           "path": "/type-of-enquiry"
@@ -914,6 +954,7 @@
     },
     {
       "path": "/type-of-enquiry-LAPH",
+      "section": "typeOfEnquiryLAPH",
       "title": "Type of enquiry",
       "components": [
         {
@@ -943,6 +984,25 @@
           "schema": {}
         }
       ],
+      "next": [
+        {
+          "path": "/type-of-enquiry-LAPH-summary"
+        }
+      ]
+    },
+    {
+      "path": "/type-of-enquiry-LAPH-summary",
+      "section": "typeOfEnquiryLAPH",
+      "controller": "MiniSummaryPageController",
+      "title": "Confirm the information before submitting",
+      "customButtonText": "Confirm and Continue",
+      "subtitle": "You will not be able to change your answer later once confirmed.",
+      "options": {
+        "content": "Please check your details and click the 'Submit' button.",
+        "customText": {
+          "title": "Check your answers"
+        }
+      },
       "next": [
         {
           "path": "/how-can-we-help",
@@ -1302,10 +1362,13 @@
     },
     {
       "path": "/summary",
+      "controller": "CustomSummaryPageController",
       "title": "Check the details before submitting",
       "components": [],
-      "next": [],
-      "controller": "./pages/summary.js"
+      "options": {
+        "disabledChangeFields": ["tUKBgj", "VeQCVM", "wyvXTj"]
+      },
+      "next": []
     }
   ],
   "lists": [
@@ -2198,7 +2261,23 @@
       ]
     }
   ],
-  "sections": [],
+  "sections": [
+    {
+      "name": "whichOrganisationValidated",
+      "title": "whichOrganisationValidated",
+      "hideTitle": true
+    },
+    {
+      "name": "typeOfEnquiry",
+      "title": "Type of enquiry",
+      "hideTitle": true
+    },
+    {
+      "name": "typeOfEnquiryLAPH",
+      "title": "Type of enquiry",
+      "hideTitle": true
+    }
+  ],
   "conditions": [
     {
       "displayName": "Other",
@@ -2252,7 +2331,7 @@
         "conditions": [
           {
             "field": {
-              "name": "tUKBgj",
+              "name": "typeOfEnquiry.tUKBgj",
               "type": "RadiosField",
               "display": "Which option best matches your query?"
             },
@@ -2274,7 +2353,7 @@
         "conditions": [
           {
             "field": {
-              "name": "tUKBgj",
+              "name": "typeOfEnquiry.tUKBgj",
               "type": "RadiosField",
               "display": "Which option best matches your query?"
             },
@@ -2296,7 +2375,7 @@
         "conditions": [
           {
             "field": {
-              "name": "tUKBgj",
+              "name": "typeOfEnquiry.tUKBgj",
               "type": "RadiosField",
               "display": "Which option best matches your query?"
             },
@@ -2318,7 +2397,7 @@
         "conditions": [
           {
             "field": {
-              "name": "tUKBgj",
+              "name": "typeOfEnquiry.tUKBgj",
               "type": "RadiosField",
               "display": "Which option best matches your query?"
             },
@@ -2340,7 +2419,7 @@
         "conditions": [
           {
             "field": {
-              "name": "tUKBgj",
+              "name": "typeOfEnquiry.tUKBgj",
               "type": "RadiosField",
               "display": "Which option best matches your query?"
             },
@@ -2362,7 +2441,7 @@
         "conditions": [
           {
             "field": {
-              "name": "tUKBgj",
+              "name": "typeOfEnquiry.tUKBgj",
               "type": "RadiosField",
               "display": "Which option best matches your query?"
             },
@@ -2376,7 +2455,7 @@
           {
             "coordinator": "or",
             "field": {
-              "name": "tUKBgj",
+              "name": "typeOfEnquiry.tUKBgj",
               "type": "RadiosField",
               "display": "Which option best matches your query?"
             },
@@ -2398,7 +2477,7 @@
         "conditions": [
           {
             "field": {
-              "name": "wyvXTj",
+              "name": "whichOrganisationValidated.wyvXTj",
               "type": "RadiosField",
               "display": "Which organisation do you work for?"
             },
@@ -2420,7 +2499,7 @@
         "conditions": [
           {
             "field": {
-              "name": "wyvXTj",
+              "name": "whichOrganisationValidated.wyvXTj",
               "type": "RadiosField",
               "display": "Which organisation do you work for?"
             },
@@ -2442,7 +2521,7 @@
         "conditions": [
           {
             "field": {
-              "name": "VeQCVM",
+              "name": "typeOfEnquiryLAPH.VeQCVM",
               "type": "RadiosField",
               "display": "Which option best matches your enquiry? - LAPH user"
             },
@@ -2464,7 +2543,7 @@
         "conditions": [
           {
             "field": {
-              "name": "VeQCVM",
+              "name": "typeOfEnquiryLAPH.VeQCVM",
               "type": "RadiosField",
               "display": "Which option best matches your enquiry? - LAPH user"
             },
@@ -2486,7 +2565,7 @@
         "conditions": [
           {
             "field": {
-              "name": "VeQCVM",
+              "name": "typeOfEnquiryLAPH.VeQCVM",
               "type": "RadiosField",
               "display": "Which option best matches your enquiry? - LAPH user"
             },
@@ -2508,7 +2587,7 @@
         "conditions": [
           {
             "field": {
-              "name": "tUKBgj",
+              "name": "typeOfEnquiry.tUKBgj",
               "type": "RadiosField",
               "display": "Which option best matches your enquiry?"
             },
@@ -2522,7 +2601,7 @@
           {
             "coordinator": "or",
             "field": {
-              "name": "VeQCVM",
+              "name": "typeOfEnquiryLAPH.VeQCVM",
               "type": "RadiosField",
               "display": "Which option best matches your enquiry? - LAPH user"
             },
@@ -2544,7 +2623,7 @@
         "conditions": [
           {
             "field": {
-              "name": "tUKBgj",
+              "name": "typeOfEnquiry.tUKBgj",
               "type": "RadiosField",
               "display": "Which option best matches your enquiry?"
             },
@@ -2558,7 +2637,7 @@
           {
             "coordinator": "or",
             "field": {
-              "name": "tUKBgj",
+              "name": "typeOfEnquiry.tUKBgj",
               "type": "RadiosField",
               "display": "Which option best matches your enquiry?"
             },
@@ -2572,7 +2651,7 @@
           {
             "coordinator": "or",
             "field": {
-              "name": "tUKBgj",
+              "name": "typeOfEnquiry.tUKBgj",
               "type": "RadiosField",
               "display": "Which option best matches your enquiry?"
             },
@@ -2594,7 +2673,7 @@
         "conditions": [
           {
             "field": {
-              "name": "wyvXTj",
+              "name": "whichOrganisationValidated.wyvXTj",
               "type": "RadiosField",
               "display": "Which organisation do you work for?"
             },
@@ -2638,5 +2717,5 @@
     "feedbackForm": true,
     "url": "https://submit.forms.service.gov.uk/form/7932/give-feedback-on-knowledge-and-library-services-kls/30055"
   },
-  "jwtKey": "${KLSJwtKey}"
+  "jwtKey": "oadfbadosif"
 }

--- a/runner/src/server/forms/kls-enquiries.json
+++ b/runner/src/server/forms/kls-enquiries.json
@@ -206,13 +206,8 @@
       "section": "typeOfEnquiry",
       "controller": "MiniSummaryPageController",
       "title": "Confirm the information before submitting",
-      "customButtonText": "Confirm and Continue",
-      "subtitle": "You will not be able to change your answer later once confirmed.",
       "options": {
-        "content": "Please check your details and click the 'Submit' button.",
-        "customText": {
-          "title": "Check your answers"
-        }
+        "subtitle": "You will not be able to change your answer later once confirmed."
       },
       "next": [
         {
@@ -930,13 +925,8 @@
       "section": "whichOrganisationValidated",
       "controller": "MiniSummaryPageController",
       "title": "Confirm the information before submitting",
-      "customButtonText": "Confirm and Continue",
-      "subtitle": "You will not be able to change your answer later once confirmed.",
       "options": {
-        "content": "Please check your details and click the 'Submit' button.",
-        "customText": {
-          "title": "Check your answers"
-        }
+        "subtitle": "You will not be able to change your answer later once confirmed."
       },
       "next": [
         {
@@ -995,13 +985,8 @@
       "section": "typeOfEnquiryLAPH",
       "controller": "MiniSummaryPageController",
       "title": "Confirm the information before submitting",
-      "customButtonText": "Confirm and Continue",
-      "subtitle": "You will not be able to change your answer later once confirmed.",
       "options": {
-        "content": "Please check your details and click the 'Submit' button.",
-        "customText": {
-          "title": "Check your answers"
-        }
+        "subtitle": "You will not be able to change your answer later once confirmed."
       },
       "next": [
         {
@@ -2717,5 +2702,5 @@
     "feedbackForm": true,
     "url": "https://submit.forms.service.gov.uk/form/7932/give-feedback-on-knowledge-and-library-services-kls/30055"
   },
-  "jwtKey": "oadfbadosif"
+  "jwtKey": "${KLSJwtKey}"
 }

--- a/runner/src/server/plugins/engine/pageControllers/CustomSummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/CustomSummaryPageController.ts
@@ -30,6 +30,7 @@ export class CustomSummaryPageController extends PageController {
     this.returnUrlParameter = `?returnUrl=${encodeURIComponent(returnPath)}`;
     this.options = pageDef?.options ?? DEFAULT_OPTIONS;
     this.options.customText ??= DEFAULT_OPTIONS.customText;
+    this.options.disabledChangeFields ??= [];
   }
   /**
    * Returns an async function. This is called in plugin.ts when there is a GET request at `/{id}/{path*}`,
@@ -360,7 +361,10 @@ export class CustomSummaryPageController extends PageController {
         "Summary",
         `${request.url.pathname}${request.url.search}`
       );
-      relativeFeedbackUrl.setParam(feedbackReturnInfoKey, returnInfo.toString());
+      relativeFeedbackUrl.setParam(
+        feedbackReturnInfoKey,
+        returnInfo.toString()
+      );
       return relativeFeedbackUrl.toString();
     }
 
@@ -397,7 +401,7 @@ export class CustomSummaryPageController extends PageController {
       component: FormComponent,
       parentComponent?: FormComponent
     ): any[] => {
-      const rows = [];
+      const rows: any[] = [];
 
       // Process the current component if it has a name (is a form field)
       if (component.name) {
@@ -427,15 +431,17 @@ export class CustomSummaryPageController extends PageController {
           value: {
             text: valueText || "Not supplied",
           },
-          actions: {
-            items: [
-              {
-                text: "Change",
-                visuallyHiddenText: displayTitle,
-                href: returnPath,
+          actions: this.options.disabledChangeFields.includes(component.name)
+            ? undefined
+            : {
+                items: [
+                  {
+                    text: "Change",
+                    visuallyHiddenText: displayTitle,
+                    href: returnPath,
+                  },
+                ],
               },
-            ],
-          },
         });
       }
 


### PR DESCRIPTION
# Description
Included intermediate summary pages for mega form and sections

## Context
The challenge of this PR was that when you use `disableChangingFromSummary` this gets disabled form the mini and from the main summary page so I found a way arround this using the custom summary page component

## Changes
- Implemented custom summary page component in KLS form 
- Added functionality for a removing change buttons in Custom Summary form 
-
## Type of change

What is the type of change you are making?

- [ ] Chore or documentation (non-breaking change that does not add functionality)
- [ ] ADR (Architectural Decision Record, non-breaking change that documents or proposes a decision)
- [ ] Refactor (non-breaking change that improves code quality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### PR title

PR titles should be prefixed with the type of change you are making, based on the [README.md#versioning](https://github.com/XGovFormBuilder/digital-form-builder?tab=readme-ov-file#versioning).
This is so that when performing a squash merge, the PR title is automatically used as the commit message.

Have you updated the PR title to match the type of change you are making?

- [ ] Yes
- [ ] No, I need help or guidance

# Testing

<!--
Several departments use XGovFormBuilder in production.
Automated tests help ensure that changes do not break existing functionality for another department.

Maintainers are sympathetic to the time constraints of government departments, but please try to be good citizens and add tests when possible.
-->

## Automated tests

Have you added automated tests?

- [ ] Yes, unit or integration tests
- [ ] Yes, end-to-end (cypress) tests
- [ ] No, tests are not required for this change
- [ ] No, I need help or guidance
- [ ] No (explain why tests are not required or can't be added at this time)

## Manual tests

Have you manually tested your changes?

- [ ] Yes
- [ ] No, manual tests are not required or sufficiently covered by automated tests

Have you attached an example form JSON or snippet for the reviewer in this PR?

- [ ] Yes
- [ ] No, any existing form can be used
- [ ] No, it is not required or not applicable

### Steps to test

<!--
Only fill out this section if you answered "Yes" to manually testing your changes.

In this section
- describe the tests that you ran to verify your changes
- provide instructions and a form JSON or snippet so we can reproduce the test if necessary

If uploading a form JSON, use the "attach files" feature in GitHub PR.
-->

1. Step 1
2. Step 2

# Documentation

Have you updated the documentation?

- [ ] Yes, I have updated [./docs](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs) for this change since additional explanation or steps to use/configure the feature is required
- [ ] Yes, I have added or updated an [ADR](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs/adr) for this change since it is large, complex, or has significant architectural implications
- [ ] Yes, I have added inline comments for hard-to-understand areas
- [ ] No, I am not sure if documentation is required
- [ ] No, documentation is not required for this change

# Discussion

> [!WARNING]
>
> Large or complex changes may require discussion with the maintainers before they can be merged. If it has not yet been discussed, it may delay the review process

Have you discussed this change with the maintainers?

- [ ] Yes, I have discussed this change with the maintainers on slack, email or via GitHub issues
- [ ] Yes, this change is an ADR to help kick-off discussion
- [ ] No, this change is small and does not require discussion
- [ ] No, I am not sure if one is required
