### PR TITLE
Feature - Extended Custom summary page component aligning to changes made in BasePageController - Updated mega form checkpoint summaries (example usage))

### DIFF
--- a/runner/src/server/forms/kls-enquiries.json
+++ b/runner/src/server/forms/kls-enquiries.json
@@ -205,7 +205,7 @@
       "path": "/type-of-enquiry-summary",
       "section": "typeOfEnquiry",
       "controller": "MiniSummaryPageController",
-      "title": "Confirm the information before submitting",
+      "title": "Confirm your enquiry type",
       "options": {
         "subtitle": "You will not be able to change your answer later once confirmed."
       },
@@ -924,7 +924,7 @@
       "path": "/which-organisation-do-you-work-for-summary",
       "section": "whichOrganisationValidated",
       "controller": "MiniSummaryPageController",
-      "title": "Confirm the information before submitting",
+      "title": "Confirm your organisation",
       "options": {
         "subtitle": "You will not be able to change your answer later once confirmed."
       },
@@ -984,7 +984,7 @@
       "path": "/type-of-enquiry-LAPH-summary",
       "section": "typeOfEnquiryLAPH",
       "controller": "MiniSummaryPageController",
-      "title": "Confirm the information before submitting",
+      "title": "Confirm your enquiry type",
       "options": {
         "subtitle": "You will not be able to change your answer later once confirmed."
       },
@@ -1350,7 +1350,7 @@
       "controller": "CustomSummaryPageController",
       "title": "Check the details before submitting",
       "components": [],
-      "customButtonText": "Confirm and Submit",
+      "customButtonText": "Confirm and submit",
       "options": {
         "hiddenFields": ["ZpmVWP"],
         "disabledChangeFields": ["tUKBgj", "VeQCVM", "wyvXTj"]

--- a/runner/src/server/forms/kls-enquiries.json
+++ b/runner/src/server/forms/kls-enquiries.json
@@ -164,6 +164,7 @@
     },
     {
       "path": "/type-of-enquiry",
+      "section": "typeOfEnquiry",
       "title": "Type of enquiry",
       "components": [
         {
@@ -182,7 +183,7 @@
               "any.only": "Select the option that best matches your enquiry",
               "string.empty": "Select the option that best matches your enquiry"
             },
-            "disableChangingFromSummary": true,
+            "disableChangingFromSummary": false,
             "exposeToContext": false
           },
           "type": "RadiosField",
@@ -194,6 +195,20 @@
           "schema": {}
         }
       ],
+      "next": [
+        {
+          "path": "/type-of-enquiry-summary"
+        }
+      ]
+    },
+    {
+      "path": "/type-of-enquiry-summary",
+      "section": "typeOfEnquiry",
+      "controller": "MiniSummaryPageController",
+      "title": "Confirm the information before submitting",
+      "options": {
+        "subtitle": "You will not be able to change your answer later once confirmed."
+      },
       "next": [
         {
           "path": "/current-awareness",
@@ -876,6 +891,7 @@
     {
       "path": "/which-organisation-do-you-work-for-validated",
       "title": "Which organisation do you work for?",
+      "section": "whichOrganisationValidated",
       "disableBackLink": true,
       "components": [
         {
@@ -886,7 +902,7 @@
               "any.only": "Select the organisation you work for",
               "string.empty": "Select the organisation you work for"
             },
-            "disableChangingFromSummary": true
+            "disableChangingFromSummary": false
           },
           "type": "RadiosField",
           "title": "Which organisation do you work for?",
@@ -898,6 +914,20 @@
           }
         }
       ],
+      "next": [
+        {
+          "path": "/which-organisation-do-you-work-for-summary"
+        }
+      ]
+    },
+    {
+      "path": "/which-organisation-do-you-work-for-summary",
+      "section": "whichOrganisationValidated",
+      "controller": "MiniSummaryPageController",
+      "title": "Confirm the information before submitting",
+      "options": {
+        "subtitle": "You will not be able to change your answer later once confirmed."
+      },
       "next": [
         {
           "path": "/type-of-enquiry"
@@ -914,6 +944,7 @@
     },
     {
       "path": "/type-of-enquiry-LAPH",
+      "section": "typeOfEnquiryLAPH",
       "title": "Type of enquiry",
       "components": [
         {
@@ -943,6 +974,20 @@
           "schema": {}
         }
       ],
+      "next": [
+        {
+          "path": "/type-of-enquiry-LAPH-summary"
+        }
+      ]
+    },
+    {
+      "path": "/type-of-enquiry-LAPH-summary",
+      "section": "typeOfEnquiryLAPH",
+      "controller": "MiniSummaryPageController",
+      "title": "Confirm the information before submitting",
+      "options": {
+        "subtitle": "You will not be able to change your answer later once confirmed."
+      },
       "next": [
         {
           "path": "/how-can-we-help",
@@ -1302,10 +1347,13 @@
     },
     {
       "path": "/summary",
+      "controller": "CustomSummaryPageController",
       "title": "Check the details before submitting",
       "components": [],
-      "next": [],
-      "controller": "./pages/summary.js"
+      "options": {
+        "disabledChangeFields": ["tUKBgj", "VeQCVM", "wyvXTj"]
+      },
+      "next": []
     }
   ],
   "lists": [
@@ -2198,7 +2246,23 @@
       ]
     }
   ],
-  "sections": [],
+  "sections": [
+    {
+      "name": "whichOrganisationValidated",
+      "title": "whichOrganisationValidated",
+      "hideTitle": true
+    },
+    {
+      "name": "typeOfEnquiry",
+      "title": "Type of enquiry",
+      "hideTitle": true
+    },
+    {
+      "name": "typeOfEnquiryLAPH",
+      "title": "Type of enquiry",
+      "hideTitle": true
+    }
+  ],
   "conditions": [
     {
       "displayName": "Other",
@@ -2252,7 +2316,7 @@
         "conditions": [
           {
             "field": {
-              "name": "tUKBgj",
+              "name": "typeOfEnquiry.tUKBgj",
               "type": "RadiosField",
               "display": "Which option best matches your query?"
             },
@@ -2274,7 +2338,7 @@
         "conditions": [
           {
             "field": {
-              "name": "tUKBgj",
+              "name": "typeOfEnquiry.tUKBgj",
               "type": "RadiosField",
               "display": "Which option best matches your query?"
             },
@@ -2296,7 +2360,7 @@
         "conditions": [
           {
             "field": {
-              "name": "tUKBgj",
+              "name": "typeOfEnquiry.tUKBgj",
               "type": "RadiosField",
               "display": "Which option best matches your query?"
             },
@@ -2318,7 +2382,7 @@
         "conditions": [
           {
             "field": {
-              "name": "tUKBgj",
+              "name": "typeOfEnquiry.tUKBgj",
               "type": "RadiosField",
               "display": "Which option best matches your query?"
             },
@@ -2340,7 +2404,7 @@
         "conditions": [
           {
             "field": {
-              "name": "tUKBgj",
+              "name": "typeOfEnquiry.tUKBgj",
               "type": "RadiosField",
               "display": "Which option best matches your query?"
             },
@@ -2362,7 +2426,7 @@
         "conditions": [
           {
             "field": {
-              "name": "tUKBgj",
+              "name": "typeOfEnquiry.tUKBgj",
               "type": "RadiosField",
               "display": "Which option best matches your query?"
             },
@@ -2376,7 +2440,7 @@
           {
             "coordinator": "or",
             "field": {
-              "name": "tUKBgj",
+              "name": "typeOfEnquiry.tUKBgj",
               "type": "RadiosField",
               "display": "Which option best matches your query?"
             },
@@ -2398,7 +2462,7 @@
         "conditions": [
           {
             "field": {
-              "name": "wyvXTj",
+              "name": "whichOrganisationValidated.wyvXTj",
               "type": "RadiosField",
               "display": "Which organisation do you work for?"
             },
@@ -2420,7 +2484,7 @@
         "conditions": [
           {
             "field": {
-              "name": "wyvXTj",
+              "name": "whichOrganisationValidated.wyvXTj",
               "type": "RadiosField",
               "display": "Which organisation do you work for?"
             },
@@ -2442,7 +2506,7 @@
         "conditions": [
           {
             "field": {
-              "name": "VeQCVM",
+              "name": "typeOfEnquiryLAPH.VeQCVM",
               "type": "RadiosField",
               "display": "Which option best matches your enquiry? - LAPH user"
             },
@@ -2464,7 +2528,7 @@
         "conditions": [
           {
             "field": {
-              "name": "VeQCVM",
+              "name": "typeOfEnquiryLAPH.VeQCVM",
               "type": "RadiosField",
               "display": "Which option best matches your enquiry? - LAPH user"
             },
@@ -2486,7 +2550,7 @@
         "conditions": [
           {
             "field": {
-              "name": "VeQCVM",
+              "name": "typeOfEnquiryLAPH.VeQCVM",
               "type": "RadiosField",
               "display": "Which option best matches your enquiry? - LAPH user"
             },
@@ -2508,7 +2572,7 @@
         "conditions": [
           {
             "field": {
-              "name": "tUKBgj",
+              "name": "typeOfEnquiry.tUKBgj",
               "type": "RadiosField",
               "display": "Which option best matches your enquiry?"
             },
@@ -2522,7 +2586,7 @@
           {
             "coordinator": "or",
             "field": {
-              "name": "VeQCVM",
+              "name": "typeOfEnquiryLAPH.VeQCVM",
               "type": "RadiosField",
               "display": "Which option best matches your enquiry? - LAPH user"
             },
@@ -2544,7 +2608,7 @@
         "conditions": [
           {
             "field": {
-              "name": "tUKBgj",
+              "name": "typeOfEnquiry.tUKBgj",
               "type": "RadiosField",
               "display": "Which option best matches your enquiry?"
             },
@@ -2558,7 +2622,7 @@
           {
             "coordinator": "or",
             "field": {
-              "name": "tUKBgj",
+              "name": "typeOfEnquiry.tUKBgj",
               "type": "RadiosField",
               "display": "Which option best matches your enquiry?"
             },
@@ -2572,7 +2636,7 @@
           {
             "coordinator": "or",
             "field": {
-              "name": "tUKBgj",
+              "name": "typeOfEnquiry.tUKBgj",
               "type": "RadiosField",
               "display": "Which option best matches your enquiry?"
             },
@@ -2594,7 +2658,7 @@
         "conditions": [
           {
             "field": {
-              "name": "wyvXTj",
+              "name": "whichOrganisationValidated.wyvXTj",
               "type": "RadiosField",
               "display": "Which organisation do you work for?"
             },

--- a/runner/src/server/forms/kls-enquiries.json
+++ b/runner/src/server/forms/kls-enquiries.json
@@ -1350,7 +1350,9 @@
       "controller": "CustomSummaryPageController",
       "title": "Check the details before submitting",
       "components": [],
+      "customButtonText": "Confirm and Submit",
       "options": {
+        "hiddenFields": ["ZpmVWP"],
         "disabledChangeFields": ["tUKBgj", "VeQCVM", "wyvXTj"]
       },
       "next": []

--- a/runner/src/server/forms/kls-enquiries.json
+++ b/runner/src/server/forms/kls-enquiries.json
@@ -166,6 +166,7 @@
       "path": "/type-of-enquiry",
       "section": "typeOfEnquiry",
       "title": "Type of enquiry",
+      "disableBackLink": true,
       "components": [
         {
           "name": "iAFhFY",
@@ -278,6 +279,7 @@
     {
       "path": "/current-awareness",
       "title": "About your current awareness alerts query",
+      "disableBackLink": true,
       "components": [
         {
           "name": "CovnkG",
@@ -325,6 +327,7 @@
     {
       "path": "/current-awareness-LAPH",
       "title": "About your current awareness alerts query",
+      "disableBackLink": true,
       "components": [
         {
           "name": "voCgKn",
@@ -363,6 +366,7 @@
     {
       "path": "/about-your-enquiry",
       "title": "About your enquiry",
+      "disableBackLink": true,
       "components": [
         {
           "name": "yYKOmJ",
@@ -839,6 +843,7 @@
     {
       "path": "/how-can-we-help",
       "title": "How can we help?",
+      "disableBackLink": true,
       "components": [
         {
           "name": "CKlngs",
@@ -946,6 +951,7 @@
       "path": "/type-of-enquiry-LAPH",
       "section": "typeOfEnquiryLAPH",
       "title": "Type of enquiry",
+      "disableBackLink": true,
       "components": [
         {
           "name": "RlHHWZ",
@@ -958,7 +964,7 @@
         {
           "name": "VeQCVM",
           "options": {
-            "disableChangingFromSummary": true,
+            "disableChangingFromSummary": false,
             "customValidationMessages": {
               "any.required": "Select the option that best matches your enquiry",
               "any.only": "Select the option that best matches your enquiry",
@@ -1005,6 +1011,7 @@
     {
       "path": "/about-your-enquiry-RPOaaR",
       "title": "About your enquiry",
+      "disableBackLink": true,
       "components": [
         {
           "name": "fXvmRh",
@@ -1125,6 +1132,7 @@
     {
       "path": "/evidence-briefing-information",
       "title": "Evidence briefing information",
+      "disableBackLink": true,
       "components": [
         {
           "name": "jojhvk",

--- a/runner/src/server/forms/kls-training-request.json
+++ b/runner/src/server/forms/kls-training-request.json
@@ -277,6 +277,7 @@
     },
     {
       "path": "/about-you-ukhsa",
+      "disableBackLink": true,
       "section": "aboutYouUKHSA",
       "title": "About you",
       "components": [
@@ -410,6 +411,7 @@
     },
     {
       "path": "/about-you-laph",
+      "disableBackLink": true,
       "section": "aboutYouLAPH",
       "title": "About you",
       "components": [
@@ -507,6 +509,7 @@
     },
     {
       "path": "/about-you",
+      "disableBackLink": true,
       "section": "aboutYou",
       "title": "About you",
       "components": [

--- a/runner/src/server/forms/kls-training-request.json
+++ b/runner/src/server/forms/kls-training-request.json
@@ -252,7 +252,7 @@
     {
       "path": "/training-topics-summary",
       "controller": "MiniSummaryPageController",
-      "title": "Confirm the information below",
+      "title": "Confirm your personal details before submitting",
       "section": "trainingQuestions",
       "options": {
         "subtitle": "You will not be able to change your answers later once confirmed.",
@@ -492,7 +492,7 @@
     {
       "path": "/about-you-laph-summary",
       "controller": "MiniSummaryPageController",
-      "title": "Confirm the information before submitting",
+      "title": "Confirm your personal details before submitting",
       "section": "aboutYouLAPH",
       "customButtonText": "Submit",
       "options": {
@@ -578,7 +578,7 @@
       "path": "/about-you-summary",
       "customButtonText": "Submit",
       "controller": "MiniSummaryPageController",
-      "title": "Confirm the information before submitting",
+      "title": "Confirm your personal details before submitting",
       "section": "aboutYou",
       "options": {
         "content": "Please check your details and click the 'Submit' button.",

--- a/runner/src/server/plugins/engine/pageControllers/CustomSummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/CustomSummaryPageController.ts
@@ -516,4 +516,8 @@ export class CustomSummaryPageController extends PageController {
     }
     return payApiKey;
   }
+
+  get defaultButtonText() {
+    return "Confirm and send";
+  }
 }

--- a/runner/src/server/plugins/engine/pageControllers/CustomSummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/CustomSummaryPageController.ts
@@ -284,21 +284,11 @@ export class CustomSummaryPageController extends PageController {
         fullState: state,
       });
 
-      // Process each form item
-      page.components.formItems
-        .filter(
-          (component) => !this.options.hiddenFields?.includes(component.name)
-        )
-        .forEach((component) => {
-          const result = toRow(component);
-          if (Array.isArray(result)) {
-            // If result is an array (from nested components), add each item
-            section.push(...result);
-          } else {
-            // Otherwise, add the single row
-            section.push(result);
-          }
-        });
+      section.push(
+        ...page.components.formItems
+          .filter((c) => !this.options.hiddenFields?.includes(c.name))
+          .flatMap((c) => toRow(c))
+      );
 
       prev[displaySectionName] = section;
       return prev;

--- a/runner/src/server/plugins/engine/pageControllers/CustomSummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/CustomSummaryPageController.ts
@@ -285,16 +285,20 @@ export class CustomSummaryPageController extends PageController {
       });
 
       // Process each form item
-      page.components.formItems.forEach((component) => {
-        const result = toRow(component);
-        if (Array.isArray(result)) {
-          // If result is an array (from nested components), add each item
-          section.push(...result);
-        } else {
-          // Otherwise, add the single row
-          section.push(result);
-        }
-      });
+      page.components.formItems
+        .filter(
+          (component) => !this.options.hiddenFields?.includes(component.name)
+        )
+        .forEach((component) => {
+          const result = toRow(component);
+          if (Array.isArray(result)) {
+            // If result is an array (from nested components), add each item
+            section.push(...result);
+          } else {
+            // Otherwise, add the single row
+            section.push(result);
+          }
+        });
 
       prev[displaySectionName] = section;
       return prev;

--- a/runner/src/server/views/custom-summary.html
+++ b/runner/src/server/views/custom-summary.html
@@ -117,13 +117,15 @@
                   </div>
                 {% endif %}
 
-                <button type="submit" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button">
-                    {% if fees and fees.details|length %}
-                        Submit and pay
-                    {% else %}
-                        Confirm and send
-                    {% endif %}
-                </button>
+                {% if fees and fees.details|length %}
+                  <button type="submit" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button">
+                    Submit and pay
+                  </button>
+                {% else %}
+                  <button type="submit" data-prevent-double-click="true" class="govuk-button" data-module="govuk-button">
+                    {{ page.buttonText if page.buttonText else "Confirm and send" }}
+                  </button>
+                {% endif %}
 
                 {% if showPaymentSkippedWarningPage %}
                 <div class="govuk-body">

--- a/runner/src/server/views/custom-summary.html
+++ b/runner/src/server/views/custom-summary.html
@@ -46,7 +46,6 @@
                 {% else %}
                   {% set actions = [] %}
                 {% endif %}
-                
                 {% set rows = (rows.push({
                   key: {
                     text: item.label
@@ -59,7 +58,6 @@
                   }
                 }), rows) %}
               {% endfor %}
-              
               {{ govukSummaryList({
                 rows: rows
               }) }}


### PR DESCRIPTION
# Description
Adding in the checkpoint summary pages for the mega form

## Context
Included from changes to add checkpoint summary pages to mega form 
Added logic to be able to change text on `customSummaryPageComponent`

## Changes
- Added section division on changes 
- Added ability to customise the summary button on `customSummaryPageComponent`
- Note this change mimics the logic that was previously introduced in `PageContollerBase` the reason it had to be re introduced is that as it stands this `customSummaryPageComponent` does not inherit from the same template so it need for each new change to be added in the main component to be re added here

- Please note that this previously existing component is not included upstream and does not follow the main way of extended components of the rest of the repo I would suggest fixing this or adding an upstream PR to introduce the customizable functionlity as part of the main summary page -- This would allow it to be extendable and usable by everyone however

- The reason I had to use this as opposed to the standard summary page controller is because the `disableChangeButton` functionality of the miniSummary page controller cannot be set diffrently to that of the main summary page controller
-> this is because `disableChangeButton` is a parameter of the field/component as opposed to a parameter of the summary page, in my opinion this should be changed so that it takes a list on the suammary page and allows customisation similarly to how I have introduced in `customSummaryPageComponent` here 
@calum-ukhsa 
Again this is a platform level change that goes outside of the scope of my work


## Type of change

What is the type of change you are making?

- [ ] Chore or documentation (non-breaking change that does not add functionality)
- [ ] ADR (Architectural Decision Record, non-breaking change that documents or proposes a decision)
- [ ] Refactor (non-breaking change that improves code quality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### PR title

PR titles should be prefixed with the type of change you are making, based on the [README.md#versioning](https://github.com/XGovFormBuilder/digital-form-builder?tab=readme-ov-file#versioning).
This is so that when performing a squash merge, the PR title is automatically used as the commit message.

Have you updated the PR title to match the type of change you are making?

- [x] Yes
- [ ] No, I need help or guidance

# Testing
VIEW SCREENSHOTS BELOW

## Automated tests
- YES ! updated in KLS test repo !
https://github.com/UKHSA-Internal/KLS-Automation/pull/28

Have you added automated tests?

- [ ] Yes, unit or integration tests
- [ ] Yes, end-to-end (cypress) tests
- [ ] No, tests are not required for this change
- [ ] No, I need help or guidance
- [ ] No (explain why tests are not required or can't be added at this time)

## Manual tests

Have you manually tested your changes?

- [x] Yes
- [ ] No, manual tests are not required or sufficiently covered by automated tests

Have you attached an example form JSON or snippet for the reviewer in this PR?

- [x] Yes (included in form changes)
- [ ] No, any existing form can be used
- [ ] No, it is not required or not applicable

### Steps to test

1. View screenshots if required can be run on local host, all the page changes are used in a form in this PR

# Documentation

Have you updated the documentation?

- [ ] Yes, I have updated [./docs](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs) for this change since additional explanation or steps to use/configure the feature is required
- [ ] Yes, I have added or updated an [ADR](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs/adr) for this change since it is large, complex, or has significant architectural implications
- [ ] Yes, I have added inline comments for hard-to-understand areas
- [x] No, I am not sure if documentation is required
(I don't think this component should be used it was more of a workaround re-using an adhoc component that was made by someone else - as mentioned similar changes should be made to the real summary page component and introduced upstream for clean and comunal usage)
- [ ] No, documentation is not required for this change

# Discussion
Have you discussed this change with the maintainers?

- [x] Yes, I have discussed this change with the maintainers on slack, email or via GitHub issues
Included details and opportunity for discussion on the X-Gov community chat as well as speaking to @kitttang and @ebadian 
- [ ] Yes, this change is an ADR to help kick-off discussion
- [ ] No, this change is small and does not require discussion
- [ ] No, I am not sure if one is required
<img width="617" height="516" alt="Screenshot 2026-03-09 at 14 24 56" src="https://github.com/user-attachments/assets/9df47809-bac2-44da-8b4c-aa9ee16cecdf" />
<img width="549" height="813" alt="custom summary page" src="https://github.com/user-attachments/assets/91c43196-2c50-41dd-8447-ace066fa59b3" />


