### PR TITLE
Micol/browser independent

### DIFF
--- a/runner/src/server/forms/kls-enquiries.json
+++ b/runner/src/server/forms/kls-enquiries.json
@@ -37,6 +37,7 @@
     {
       "path": "/which-organisation-do-you-work-for",
       "unauthenticated": true,
+      "section": "whichOrganisation",
       "title": "Which organisation do you work for?",
       "components": [
         {
@@ -2198,7 +2199,13 @@
       ]
     }
   ],
-  "sections": [],
+  "sections": [
+    {
+      "name": "whichOrganisation",
+      "title": "whichOrganisation",
+      "hideTitle": true
+    }
+  ],
   "conditions": [
     {
       "displayName": "Other",
@@ -2208,7 +2215,7 @@
         "conditions": [
           {
             "field": {
-              "name": "ZpmVWP",
+              "name": "whichOrganisation.ZpmVWP",
               "type": "RadiosField",
               "display": "Organisation"
             },
@@ -2230,7 +2237,7 @@
         "conditions": [
           {
             "field": {
-              "name": "ZpmVWP",
+              "name": "whichOrganisation.ZpmVWP",
               "type": "RadiosField",
               "display": "Organisation"
             },

--- a/runner/src/server/plugins/engine/models/FormModel.ts
+++ b/runner/src/server/plugins/engine/models/FormModel.ts
@@ -101,7 +101,8 @@ export class FormModel {
     this.sections = def.sections;
     this.options = options;
     this.name = def.name;
-    this.serviceStartPage = def.fullStartPage || config.serviceStartPage || config.serviceName || "#";
+    this.serviceStartPage =
+      def.fullStartPage || config.serviceStartPage || config.serviceName || "#";
     this.returnTo = def.returnTo || false;
     this.values = result.value;
 
@@ -264,7 +265,10 @@ export class FormModel {
   }
 
   get conditionOptions() {
-    return { allowUnknown: true, presence: "required" };
+    return {
+      allowUnknown: true,
+      // presence: "required",
+    };
   }
 
   getList(name: string): List | [] {

--- a/runner/src/server/plugins/engine/pageControllers/MagicLinkController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/MagicLinkController.ts
@@ -23,10 +23,10 @@ export class MagicLinkController extends PageController {
 
       const validation = await validateHmac(email, hmac, requestTime, hmacKey);
 
-     //Outlook safelink consumes magic link - This bypasses it
-     if (!request.headers["user-agent"]) {
-      return h.response("Ignored bot request").code(200);
-    }
+      //Outlook safelink consumes magic link - This bypasses it
+      if (!request.headers["user-agent"]) {
+        return h.response("Ignored bot request").code(200);
+      }
 
       const { cacheService } = request.services([]);
 
@@ -50,7 +50,9 @@ export class MagicLinkController extends PageController {
           case "expired":
             return h.redirect(`/${this.model.basePath}/expired`).code(302);
           case "invalid_signature":
-            return h.redirect(`/${this.model.basePath}/incorrect-email`).code(302);
+            return h
+              .redirect(`/${this.model.basePath}/incorrect-email`)
+              .code(302);
           default:
             return h.redirect(`/${this.model.basePath}/error`).code(302);
         }
@@ -136,11 +138,12 @@ export class MagicLinkController extends PageController {
       const hmacKey = this.model.def.outputs[0].outputConfiguration.hmacKey;
 
       const validation = await validateHmac(email, hmac, requestTime, hmacKey);
-     
+
       //Outlook safelink consumes magic link - This bypasses it
       if (!request.headers["user-agent"]) {
-      return h.response("Ignored bot request").code(200);
-    }
+        return h.response("Ignored bot request").code(200);
+      }
+
       if (validation.isValid) {
         const token = Jwt.token.generate(
           { email: request.query.email },

--- a/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -73,6 +73,16 @@ export class PageControllerBase {
   constructor(model: FormModel, pageDef: { [prop: string]: any } = {}) {
     const { def } = model;
 
+    // TODO: remove sample log messgaes
+    console.log("MICLA TEST LOGS");
+    console.log(
+      "Initialising page",
+      def.name,
+      pageDef.title,
+      "with path",
+      pageDef.title
+    );
+
     // @ts-ignore
     this.def = def;
     // @ts-ignore
@@ -89,6 +99,10 @@ export class PageControllerBase {
       pageDef.disableSingleComponentAsHeading;
     this.buttonText = pageDef.customButtonText ?? this.defaultButtonText;
 
+    console.log("MICLA TEST LOGS");
+    // TODO: STILL UNSURE AS TO WHAT PAGE CONDTIONS ARE ?
+    console.log("Page condition:", this.pageDef.condition);
+    console.log("Available conditions:", Object.keys(this.model.conditions));
     // Resolve section
     this.section = model.sections?.find(
       (section) => section.name === pageDef.section
@@ -256,6 +270,8 @@ export class PageControllerBase {
    * @param suppressRepetition - cancels repetition logic
    */
   getNextPage(state: FormSubmissionState, suppressRepetition = false) {
+    console.log("Starting Get Next Page Function");
+
     if (this.repeatField && !suppressRepetition) {
       const requiredCount = reach(state, this.repeatField);
       const otherRepeatPagesInSection = this.model.pages.filter(
@@ -929,7 +945,8 @@ export class PageControllerBase {
   }
 
   get defaultNextPath() {
-    return `${this.model.basePath || ""}/summary`;
+    return `summary`;
+    // return `${this.model.basePath || ""}/summary`;
   }
 
   get validationOptions() {

--- a/runner/src/server/transforms/summaryDetails/index.ts
+++ b/runner/src/server/transforms/summaryDetails/index.ts
@@ -24,7 +24,7 @@ const closeContactParams = [
   },
 ];
 
-const klsRemoveParams = ["ZpmVWP"];
+// const klsRemoveParams = ["ZpmVWP"];
 
 const summaryDetailsTransformations: SummaryDetailsTransformationMap = {
   "close-contact-form-nl1-dev": (details) => {
@@ -132,6 +132,3 @@ const summaryDetailsTransformations: SummaryDetailsTransformationMap = {
 };
 
 module.exports = summaryDetailsTransformations;
-
-
-


### PR DESCRIPTION
## Problem Statement

The KLS magic link flow is **not browser-independent**. When a user opens the magic link in a different browser, pre-magic-link session state is absent entirely. This causes the post-authentication journey to break in two distinct ways.

---

## Root Causes Found


Behaviour when on mini summary page on new browser: 

<img width="932" height="451" alt="Screenshot 2026-03-13 at 15 21 49" src="https://github.com/user-attachments/assets/7aae787e-ace6-48b5-9250-2103b2ae3b82" />


### Issue 1 — MiniSummaryPageController cannot handle undefined sections it isn't displaying

Even though the mini summary page for `whichOrganisationValidated` has nothing to do with `whichOrganisation`, the `SummaryViewModel` appears to iterate all sections when building `details`. If any section's state is absent, it either produces an incomplete `details` array or `sectionDetails` resolves to `undefined`. The controller then calls `.items` on `undefined` and crashes with a 500.

**The page shouldn't need to know or care that another section's state is missing — but currently it does.**

---

### Issue 2 — Undefined pre-magic-link state may be breaking conditional routing logic across all pages

`getConditionEvaluationContext` in `PageControllerBase` walks the form from `startPage` forward, evaluating conditions to determine the correct path through the form. It is suspected that when `whichOrganisation` is `undefined` in the new browser session, the condition that would normally route to `which-organisation-do-you-work-for-validated` cannot be evaluated correctly, causing the walk to terminate early. If this is the case, `whichOrganisationValidated` — despite having real data in the session — may never make it into `relevantState`, causing it to be invisible to the summary and any subsequent conditional logic downstream.

**This needs further investigation.** The current hypothesis is that a single undefined pre-magic-link field may be sufficient to break the condition evaluation chain for all pages that follow it in the journey, but the exact failure point and its full downstream impact should be confirmed before a fix is implemented.

---

Resolution Approach
Two fixes should be implemented in parallel, and both are necessary.

Fix 1 — Make the magic link browser-independent by passing pre-magic-link state through the authentication flow, so the new browser session has the values it needs to evaluate conditions and render summaries correctly.

Fix 2 — Make the platform more robust against undefined state by ensuring that components, condition evaluation, and summary rendering only operate on the values they actually need. No page or controller should crash because an unrelated section has undefined state — the platform should handle absent values gracefully regardless of how they came to be missing.

The reason both fixes are needed is that Fix 1 solves the immediate magic link problem, but Fix 2 addresses a broader fragility: the platform currently assumes all prior pages in the journey will always have state, which is an assumption that can be broken in other ways beyond magic links (e.g. direct URL access, session expiry, future authentication patterns). Fix 2 makes the platform defensively correct by design, rather than relying on the magic link always providing complete state.

---

What is the type of change you are making?

- [ ] Chore or documentation (non-breaking change that does not add functionality)
- [ ] ADR (Architectural Decision Record, non-breaking change that documents or proposes a decision)
- [ ] Refactor (non-breaking change that improves code quality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### PR title

PR titles should be prefixed with the type of change you are making, based on the [README.md#versioning](https://github.com/XGovFormBuilder/digital-form-builder?tab=readme-ov-file#versioning).
This is so that when performing a squash merge, the PR title is automatically used as the commit message.

Have you updated the PR title to match the type of change you are making?

- [ ] Yes
- [ ] No, I need help or guidance

# Testing

<!--
Several departments use XGovFormBuilder in production.
Automated tests help ensure that changes do not break existing functionality for another department.

Maintainers are sympathetic to the time constraints of government departments, but please try to be good citizens and add tests when possible.
-->

## Automated tests

Have you added automated tests?

- [ ] Yes, unit or integration tests
- [ ] Yes, end-to-end (cypress) tests
- [ ] No, tests are not required for this change
- [ ] No, I need help or guidance
- [ ] No (explain why tests are not required or can't be added at this time)

## Manual tests

Have you manually tested your changes?

- [ ] Yes
- [ ] No, manual tests are not required or sufficiently covered by automated tests

Have you attached an example form JSON or snippet for the reviewer in this PR?

- [ ] Yes
- [ ] No, any existing form can be used
- [ ] No, it is not required or not applicable

### Steps to test

<!--
Only fill out this section if you answered "Yes" to manually testing your changes.

In this section
- describe the tests that you ran to verify your changes
- provide instructions and a form JSON or snippet so we can reproduce the test if necessary

If uploading a form JSON, use the "attach files" feature in GitHub PR.
-->

1. Step 1
2. Step 2

# Documentation

Have you updated the documentation?

- [ ] Yes, I have updated [./docs](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs) for this change since additional explanation or steps to use/configure the feature is required
- [ ] Yes, I have added or updated an [ADR](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs/adr) for this change since it is large, complex, or has significant architectural implications
- [ ] Yes, I have added inline comments for hard-to-understand areas
- [ ] No, I am not sure if documentation is required
- [ ] No, documentation is not required for this change

# Discussion

> [!WARNING]
>
> Large or complex changes may require discussion with the maintainers before they can be merged. If it has not yet been discussed, it may delay the review process

Have you discussed this change with the maintainers?

- [ ] Yes, I have discussed this change with the maintainers on slack, email or via GitHub issues
- [ ] Yes, this change is an ADR to help kick-off discussion
- [ ] No, this change is small and does not require discussion
- [ ] No, I am not sure if one is required
