### PR TITLE
BUG FIX - Timout Page

### DIFF
--- a/runner/src/server/plugins/router.ts
+++ b/runner/src/server/plugins/router.ts
@@ -295,12 +295,42 @@ export default {
             request.yar.reset();
           }
 
-          const { url } = request.params;
+          const { referer } = request.headers;
+          let startPage = "/";
+          let formId: string | undefined;
+
+          if (referer) {
+            const match = referer.match(/https?:\/\/[^/]+\/([^/]+).*/);
+            if (match && match.length > 1) {
+              formId = match[1];
+              startPage = `/${match[1]}`;
+            }
+          }
+
+          const form = formId ? server.app.forms[formId] : undefined;
+
+          const title = "timeout";
+          return h.view(title, {
+            name: form?.name,
+            serviceName: form?.serviceName,
+            startPage: form?.serviceStartPage,
+            feedbackLink: feedbackUrlFromRequest(request, form, title),
+          });
+        },
+      });
+
+      server.route({
+        method: "get",
+        path: "/{url}/timeout",
+        handler: async (_request: HapiRequest, h: HapiResponseToolkit) => {
+          if (_request.yar) {
+            _request.yar.reset();
+          }
+          const { url } = _request.params;
           const form = server.app.forms[url];
 
           let startPage = "/";
-          const { referer } = request.headers;
-
+          const { referer } = _request.headers;
           if (referer) {
             const match = referer.match(/https?:\/\/[^/]+\/([^/]+).*/);
             if (match && match.length > 1) {
@@ -312,8 +342,8 @@ export default {
           return h.view(title, {
             name: form.name,
             serviceName: form.serviceName,
-            StartPage: startPage,
-            feedbackLink: feedbackUrlFromRequest(request, form, title),
+            startPage: form.serviceStartPage,
+            feedbackLink: feedbackUrlFromRequest(_request, form, title),
           });
         },
       });

--- a/runner/src/server/plugins/router.ts
+++ b/runner/src/server/plugins/router.ts
@@ -295,7 +295,17 @@ export default {
             request.yar.reset();
           }
 
+          const { referer } = request.headers;
+          let startPage = "/";
           let formId: string | undefined;
+
+          if (referer) {
+            const match = referer.match(/https?:\/\/[^/]+\/([^/]+).*/);
+            if (match && match.length > 1) {
+              formId = match[1];
+              startPage = `/${match[1]}`;
+            }
+          }
 
           const form = formId ? server.app.forms[formId] : undefined;
 

--- a/runner/src/server/plugins/router.ts
+++ b/runner/src/server/plugins/router.ts
@@ -295,17 +295,7 @@ export default {
             request.yar.reset();
           }
 
-          const { referer } = request.headers;
-          let startPage = "/";
           let formId: string | undefined;
-
-          if (referer) {
-            const match = referer.match(/https?:\/\/[^/]+\/([^/]+).*/);
-            if (match && match.length > 1) {
-              formId = match[1];
-              startPage = `/${match[1]}`;
-            }
-          }
 
           const form = formId ? server.app.forms[formId] : undefined;
 
@@ -328,15 +318,6 @@ export default {
           }
           const { url } = _request.params;
           const form = server.app.forms[url];
-
-          let startPage = "/";
-          const { referer } = _request.headers;
-          if (referer) {
-            const match = referer.match(/https?:\/\/[^/]+\/([^/]+).*/);
-            if (match && match.length > 1) {
-              startPage = `/${match[1]}`;
-            }
-          }
 
           const title = "timeout";
           return h.view(title, {

--- a/runner/src/server/plugins/router.ts
+++ b/runner/src/server/plugins/router.ts
@@ -68,7 +68,7 @@ export default {
               name: form.name,
               serviceName: form.def.serviceName,
               serviceStartPage: form.serviceStartPage,
-              feedbackLink: feedbackUrlFromRequest(_request, form, title)
+              feedbackLink: feedbackUrlFromRequest(_request, form, title),
             });
           },
         },
@@ -116,7 +116,7 @@ export default {
               matomoUrl: form.def.analytics.matomoUrl,
               matomoId: form.def.analytics.matomoId,
               gtmId1: form.def.analytics.gtmId1,
-              gtmId2: form.def.analytics.gtmId2
+              gtmId2: form.def.analytics.gtmId2,
             });
           },
         },
@@ -176,7 +176,7 @@ export default {
             if (referrer) {
               redirectPath = new URL(referrer).pathname;
             }
-            
+
             const cookieName = form?.name || `${url}Page`;
 
             return h.redirect(redirectPath).state(
@@ -229,7 +229,7 @@ export default {
             name: form.name,
             serviceName: form.def.serviceName,
             serviceStartPage: form.serviceStartPage,
-            feedbackLink: feedbackUrlFromRequest(_request, form, title)
+            feedbackLink: feedbackUrlFromRequest(_request, form, title),
           });
         },
       });
@@ -270,7 +270,7 @@ export default {
             name: form.name,
             serviceName: form.serviceName,
             serviceStartPage: form.serviceStartPage,
-            feedbackLink: feedbackUrlFromRequest(_request, form, title)
+            feedbackLink: feedbackUrlFromRequest(_request, form, title),
           });
         },
       });
@@ -295,8 +295,10 @@ export default {
             request.yar.reset();
           }
 
-          let startPage = "/";
+          const { url } = request.params;
+          const form = server.app.forms[url];
 
+          let startPage = "/";
           const { referer } = request.headers;
 
           if (referer) {
@@ -306,8 +308,12 @@ export default {
             }
           }
 
-          return h.view("timeout", {
-            startPage,
+          const title = "timeout";
+          return h.view(title, {
+            name: form.name,
+            serviceName: form.serviceName,
+            StartPage: startPage,
+            feedbackLink: feedbackUrlFromRequest(request, form, title),
           });
         },
       });
@@ -315,8 +321,12 @@ export default {
   },
 };
 
-function feedbackUrlFromRequest(request: HapiRequest, form: FormModel, title: string): string | void {
-  const feedbackUrl = (form.def.feedback?.url as any);
+function feedbackUrlFromRequest(
+  request: HapiRequest,
+  form: FormModel,
+  title: string
+): string | void {
+  const feedbackUrl = form.def.feedback?.url as any;
   if (feedbackUrl) {
     if (feedbackUrl.startsWith("http")) {
       return feedbackUrl;
@@ -328,10 +338,7 @@ function feedbackUrlFromRequest(request: HapiRequest, form: FormModel, title: st
       title,
       `${request.url.pathname}${request.url.search}`
     );
-    relativeFeedbackUrl.setParam(
-      feedbackReturnInfoKey,
-      returnInfo.toString()
-    );
+    relativeFeedbackUrl.setParam(feedbackReturnInfoKey, returnInfo.toString());
     return relativeFeedbackUrl.toString();
   }
 

--- a/runner/src/server/plugins/router.ts
+++ b/runner/src/server/plugins/router.ts
@@ -318,26 +318,6 @@ export default {
           });
         },
       });
-
-      server.route({
-        method: "get",
-        path: "/{url}/timeout",
-        handler: async (_request: HapiRequest, h: HapiResponseToolkit) => {
-          if (_request.yar) {
-            _request.yar.reset();
-          }
-          const { url } = _request.params;
-          const form = server.app.forms[url];
-
-          const title = "timeout";
-          return h.view(title, {
-            name: form.name,
-            serviceName: form.serviceName,
-            startPage: form.serviceStartPage,
-            feedbackLink: feedbackUrlFromRequest(_request, form, title),
-          });
-        },
-      });
     },
   },
 };


### PR DESCRIPTION
# Description
-> Due to a bug the current version of the `timeout` page was not working 
This is is because some of the core params such as `feedbackLink` and `serviceName` were not being passed through 

I mimicked the functionality of the `/accessability-statment` template and passed these through fixing the issue for all such forms. 


## Context
Issue spotted by manual tester @Mony Rekala and detailed in the following defect stories 

https://ukhsa.atlassian.net/browse/KLSKAB-1781
https://ukhsa.atlassian.net/browse/KLSKAB-1661


## Changes

- Formatted Docuement with prettier according to repo standards (previously had linter showing errors)
- Copied funtionlity from other sections 
- Changed the start page redirect as shown because the way from before was faulty and did not work on pages that don't start with the base name such as `feedback` on report and outbreak


## Further suggestion

To avoid breaking chnages I kept the timeout path to `/timeout`

I would suggest changeing it to `{url}/timeout` so it maintains the same standard as the rest of the repo, 

this involves changing  the redirect url `runner/src/server/views/partials/modal-dialog.html`
from `"/template"` to "template"

this is really easy and I have tested this 

## Type of change

What is the type of change you are making?

- [ ] Chore or documentation (non-breaking change that does not add functionality)
- [ ] ADR (Architectural Decision Record, non-breaking change that documents or proposes a decision)
- [ ] Refactor (non-breaking change that improves code quality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### PR title

PR titles should be prefixed with the type of change you are making, based on the [README.md#versioning](https://github.com/XGovFormBuilder/digital-form-builder?tab=readme-ov-file#versioning).
This is so that when performing a squash merge, the PR title is automatically used as the commit message.

Have you updated the PR title to match the type of change you are making?

- [x] Yes
- [ ] No, I need help or guidance

# Testing
## Automated tests

Have you added automated tests?

- [ ] Yes, unit or integration tests
- [ ] Yes, end-to-end (cypress) tests
- [x] No, tests are not required for this change
!!! this section of the stack is never tested 
- [ ] No, I need help or guidance
- [ ] No (explain why tests are not required or can't be added at this time)

## Manual tests

Have you manually tested your changes?

-  [x] Yes
- [ ] No, manual tests are not required or sufficiently covered by automated tests


screenshot provided below 


Have you attached an example form JSON or snippet for the reviewer in this PR?

- [x] Yes
- [ ] No, any existing form can be used
- [ ] No, it is not required or not applicable

### Steps to test


1. Run on local host: 

change sessionTimout to 0.1 minutes to view timeout page immediatly

# Documentation

Have you updated the documentation?

- [ ] Yes, I have updated [./docs](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs) for this change since additional explanation or steps to use/configure the feature is required
- [ ] Yes, I have added or updated an [ADR](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs/adr) for this change since it is large, complex, or has significant architectural implications
- [ ] Yes, I have added inline comments for hard-to-understand areas
- [x] No, I am not sure if documentation is required
- [ ] No, documentation is not required for this change


NO documentation is required
# Discussion
discussion is foudn above and also this is a bug across forms so I have raised it in the X-gov communitiy chat 
- [ ] Yes, I have discussed this change with the maintainers on slack, email or via GitHub issues
- [ ] Yes, this change is an ADR to help kick-off discussion
- [ ] No, this change is small and does not require discussion
- [ ] No, I am not sure if one is required
