### PR TITLE
Feature: XGOV SOW37 Automated Form Deployment

### DIFF
--- a/.github/workflows/auto-forms-deployment-caller.yml
+++ b/.github/workflows/auto-forms-deployment-caller.yml
@@ -77,9 +77,9 @@ jobs:
             owner: '${{ secrets.DEPLOYMENT_OWNER }}',
             repo: '${{ secrets.DEPLOYMENT_REPO }}',
             workflow_id: 'form-only-deployment.yml',
-            ref: 'xgf-65',
+            ref: 'trunk',
             inputs: {
-              branch: 'xgf-65',
+              branch: 'v2',
               commit_message: '${{ github.event.head_commit.message }}',
               caller_run_id: '${{ github.run_id }}'
             }

--- a/.github/workflows/auto-forms-deployment-caller.yml
+++ b/.github/workflows/auto-forms-deployment-caller.yml
@@ -1,22 +1,44 @@
 # This workflow automatically calls to deploy if a change is made to only the forms folder
 
-name: Automatic Forms Deployment Caller
+name: Automated Form Deployment
 
 # Workflow runs automatically when the form folder is updated
 on:
   push:
     branches:
-      - xgf-65
+      - v2
     paths:
       - 'runner/src/server/forms/**'
+  workflow_dispatch: 
+    inputs:
+      success:
+        description: "Did the deployment succeed"
+        type: boolean
+        required: true
+        default: false
+      auto_deploy_status:
+        description: "Failure status message"
+        type: string
+        required: false
+      commit_message:
+        description: "Triggering commit message"
+        type: string
+        required: true
+      caller_run_id:
+        description: "Workflow Caller ID"
+        type: string
+        required: true
 
 jobs:
-  check_files:
-    outputs:
-      should_deploy: ${{ steps.check_file_path.outputs.form_only }}
+  Trigger-Deployment:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+        actions: read
+    outputs:
+        should_deploy: ${{ steps.check_file_path.outputs.should_deploy }}
     env:
-      FORMS_FOLDER: 'runner/src/server/forms/'
+        FORMS_FOLDER: 'runner/src/server/forms/'
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -29,22 +51,14 @@ jobs:
         NON_FORM_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} -- ":(exclude)${{ env.FORMS_FOLDER }}" | wc -l)
         if [ "$NON_FORM_FILES" -eq 0 ]; then
           echo "Only form changes found, able to deploy"
-          FORM_ONLY="true"
+          echo "should_deploy=true" >> $GITHUB_OUTPUT
         else
           echo "Non-form changes found, do not deploy"
-          FORM_ONLY="false"
+          echo "should_deploy=false" >> $GITHUB_OUTPUT
         fi
 
-        echo "form_only=$FORM_ONLY" >> "$GITHUB_OUTPUT"
-    
-  dispatch:
-    runs-on: ubuntu-latest
-    needs: check_files
-    if: needs.check_files.outputs.should_deploy == 'true'
-    permissions:
-      actions: read
-    steps:
     - name: Generate token
+      if: steps.check_file_path.outputs.should_deploy == 'true'
       uses: actions/create-github-app-token@v2
       id: app-token
       with:
@@ -52,7 +66,9 @@ jobs:
         private-key: ${{ secrets.DEPLOYMENT_APP_KEY }}
         owner: ${{ secrets.DEPLOYMENT_OWNER }}
         repositories: ${{ secrets.DEPLOYMENT_REPO }}
+
     - name: Call deployment repo
+      if: steps.check_file_path.outputs.should_deploy == 'true'
       uses: actions/github-script@v8
       with:
         github-token: ${{ steps.app-token.outputs.token }}
@@ -64,6 +80,18 @@ jobs:
             ref: 'xgf-65',
             inputs: {
               branch: 'xgf-65',
-              environment: 'dev',
+              commit_message: '${{ github.event.head_commit.message }}',
+              caller_run_id: '${{ github.run_id }}'
             }
           });
+
+  Print-Status:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print Deployment Status
+        run: |
+          echo "Deployment Success: ${{ github.event.inputs.success }}"
+          echo "Deployment Status Message: ${{ github.event.inputs.auto_deploy_status }}"
+          echo "Triggering Commit Message: ${{ github.event.inputs.commit_message }}"
+          echo "Caller Run ID: ${{ github.event.inputs.caller_run_id }}"


### PR DESCRIPTION
> [!NOTE]
> This template is designed to help both contributors and maintainers. It is a checklist to ensure all necessary
> information is provided, and prompts contributors on any contribution guidelines they have missed.
>
> Do not remove sections.
> They are important for the review process and help maintainers ensure quality and good documentation across the
> project.
>
> Some checkboxes will not apply to every change, so feel free to leave them unchecked if they are not relevant.

# Description

## Context

- Workflow for automated deployment when form only changes are made. Will report status back after deployment job finishes.

## Changes

- New deployment pipeline triggers when a change is made to the forms folder on v2.
- Checks if there have been changes made outside the forms folder, will not try to deploy if so
- This check will be made again inside the deployment repo with the commit to be deployed, to prevent an edge case where a non-form change is merged in after the check in the caller action, but before the repo has been checked out to make a new image.
- Workflow called again after the deployment action is finished to report the deployment status

## Type of change

What is the type of change you are making?

- [ ] Chore or documentation (non-breaking change that does not add functionality)
- [ ] ADR (Architectural Decision Record, non-breaking change that documents or proposes a decision)
- [ ] Refactor (non-breaking change that improves code quality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### PR title

PR titles should be prefixed with the type of change you are making, based on the [README.md#versioning](https://github.com/XGovFormBuilder/digital-form-builder?tab=readme-ov-file#versioning).
This is so that when performing a squash merge, the PR title is automatically used as the commit message.

Have you updated the PR title to match the type of change you are making?

- [x] Yes
- [ ] No, I need help or guidance

# Testing

<!--
Several departments use XGovFormBuilder in production.
Automated tests help ensure that changes do not break existing functionality for another department.

Maintainers are sympathetic to the time constraints of government departments, but please try to be good citizens and add tests when possible.
-->

## Automated tests

Have you added automated tests?

- [ ] Yes, unit or integration tests
- [ ] Yes, end-to-end (cypress) tests
- [x] No, tests are not required for this change
- [ ] No, I need help or guidance
- [ ] No (explain why tests are not required or can't be added at this time)

## Manual tests

Have you manually tested your changes?

- [x] Yes
- [ ] No, manual tests are not required or sufficiently covered by automated tests

Have you attached an example form JSON or snippet for the reviewer in this PR?

- [ ] Yes
- [ ] No, any existing form can be used
- [x] No, it is not required or not applicable

### Steps to test

<!--
Only fill out this section if you answered "Yes" to manually testing your changes.

In this section
- describe the tests that you ran to verify your changes
- provide instructions and a form JSON or snippet so we can reproduce the test if necessary

If uploading a form JSON, use the "attach files" feature in GitHub PR.
-->

1. Step 1
2. Step 2

# Documentation

Have you updated the documentation?

- [x] Yes, I have updated https://ukhsa.atlassian.net/wiki/spaces/IDT/pages/448889203/D02+Decoupling+Form+Deployment+from+Infrastructure+Deployment

# Discussion

> [!WARNING]
>
> Large or complex changes may require discussion with the maintainers before they can be merged. If it has not yet been discussed, it may delay the review process

Have you discussed this change with the maintainers?

- [x] Yes, I have discussed this change with the maintainers on slack, email or via GitHub issues
- [ ] Yes, this change is an ADR to help kick-off discussion
- [ ] No, this change is small and does not require discussion
- [ ] No, I am not sure if one is required
