### PR TITLE
[PERSONAL UTIL NOT TO MERGE] - BugFix - resolved exessive logging 

### DIFF
--- a/runner/src/server/plugins/crumb.ts
+++ b/runner/src/server/plugins/crumb.ts
@@ -25,10 +25,10 @@ export const configureCrumbPlugin = (
         const isSkippedRoute =
           skippedRoutes.find((route) => `${request.path}`.startsWith(route)) ??
           false;
-        if (isSkippedRoute) {
+        if (isSkippedRoute && request.path !== "/session/keep-alive") {
           request.logger.info(
-            ["Crumb", "CSRF", "Skipping route"],
-            `${request.url}`
+            ["Crumb", "CSRF"],
+            `Skipping CSRF check on ${request.path}`
           );
         }
 

--- a/runner/src/server/plugins/initialiseSession/initialiseSession.ts
+++ b/runner/src/server/plugins/initialiseSession/initialiseSession.ts
@@ -27,28 +27,6 @@ export const initialiseSession: Plugin<InitialiseSession> = {
   name: "initialiseSession",
   register: async function (server, options) {
     const { safelist } = options;
-
-    server.route({
-      method: "POST",
-      path: "/session/keep-alive",
-      options: {
-        auth: false,
-      },
-      handler: async (request, h) => {
-        const { cacheService } = request.services([]);
-
-        // Read existing state
-        const state = await cacheService.getState(request);
-
-        if (state) {
-          // Re-save without changes → refresh TTL
-          await cacheService.mergeState(request, {});
-        }
-
-        return h.response().code(204);
-      },
-    });
-
     server.route({
       method: "GET",
       path: "/session/{token}",
@@ -142,6 +120,27 @@ export const initialiseSession: Plugin<InitialiseSession> = {
         });
 
         return h.response({ token }).code(201);
+      },
+    });
+
+    server.route({
+      method: "POST",
+      path: "/session/keep-alive",
+      options: {
+        auth: false,
+      },
+      handler: async (request, h) => {
+        const { cacheService } = request.services([]);
+
+        // Read existing state
+        const state = await cacheService.getState(request);
+
+        if (state) {
+          // Re-save without changes → refresh TTL
+          await cacheService.mergeState(request, {});
+        }
+
+        return h.response().code(204);
       },
     });
   },

--- a/runner/src/server/plugins/initialiseSession/initialiseSession.ts
+++ b/runner/src/server/plugins/initialiseSession/initialiseSession.ts
@@ -27,6 +27,28 @@ export const initialiseSession: Plugin<InitialiseSession> = {
   name: "initialiseSession",
   register: async function (server, options) {
     const { safelist } = options;
+
+    server.route({
+      method: "POST",
+      path: "/session/keep-alive",
+      options: {
+        auth: false,
+      },
+      handler: async (request, h) => {
+        const { cacheService } = request.services([]);
+
+        // Read existing state
+        const state = await cacheService.getState(request);
+
+        if (state) {
+          // Re-save without changes → refresh TTL
+          await cacheService.mergeState(request, {});
+        }
+
+        return h.response().code(204);
+      },
+    });
+
     server.route({
       method: "GET",
       path: "/session/{token}",
@@ -120,27 +142,6 @@ export const initialiseSession: Plugin<InitialiseSession> = {
         });
 
         return h.response({ token }).code(201);
-      },
-    });
-
-    server.route({
-      method: "POST",
-      path: "/session/keep-alive",
-      options: {
-        auth: false,
-      },
-      handler: async (request, h) => {
-        const { cacheService } = request.services([]);
-
-        // Read existing state
-        const state = await cacheService.getState(request);
-
-        if (state) {
-          // Re-save without changes → refresh TTL
-          await cacheService.mergeState(request, {});
-        }
-
-        return h.response().code(204);
       },
     });
   },

--- a/runner/src/server/plugins/logging.ts
+++ b/runner/src/server/plugins/logging.ts
@@ -22,6 +22,5 @@ export default {
       paths: config.logRedactPaths,
       censor: "REDACTED",
     },
-    // ignorePaths: [/^\/assets/, "/session/keep-alive"],
   },
 };

--- a/runner/src/server/plugins/logging.ts
+++ b/runner/src/server/plugins/logging.ts
@@ -15,8 +15,11 @@ export default {
     debug: config.isDev,
     logRequestStart: false,
     logRequestComplete: false,
-    ignoreFunc: (_options, request) => {
-      return request.path.startsWith("/assets");
+    ignoreFunc: async (_options, request) => {
+      return (
+        request.path.startsWith("/assets") ||
+        request.path === "/session/keep-alive"
+      );
     },
     redact: {
       paths: config.logRedactPaths,

--- a/runner/src/server/plugins/logging.ts
+++ b/runner/src/server/plugins/logging.ts
@@ -1,5 +1,6 @@
 import config from "../config";
 import pino from "hapi-pino";
+
 export default {
   plugin: pino,
   options: {
@@ -12,13 +13,15 @@ export default {
       },
     },
     debug: config.isDev,
-    logRequestStart: config.isDev,
-    logRequestComplete: config.isDev,
-    ignoreFunc: (_options, request) =>
-      request.path.startsWith("/assets") || request.url.contains("assets"),
+    logRequestStart: false,
+    logRequestComplete: false,
+    ignoreFunc: (_options, request) => {
+      return request.path.startsWith("/assets");
+    },
     redact: {
       paths: config.logRedactPaths,
       censor: "REDACTED",
     },
+    // ignorePaths: [/^\/assets/, "/session/keep-alive"],
   },
 };


### PR DESCRIPTION
# Description
In development, clear and well-levelled logs are critical — without them it is 
very difficult to distinguish expected behaviour from real errors and trace the 
root cause of issues quickly.

hence I chose to remove the very large and verbose logs that hide the other logs

`session/keep-alive`
`assets`

## Background
While investigating noisy logs in the `configureCrumbPlugin`, I initially attempted
to reduce logging around CSRF skip behaviour. However on closer inspection the logs
were actually surfacing a real bug rather than noise.

## Issue

The `POST /session/keep-alive` route is dead code and has never executed. Hapi
matches requests against `POST /session/{formId}` first (where `formId = "keep-alive"`),
so the dedicated keep-alive handler is never reached.

The `{formId}` handler then crashes with a 500 on every keep-alive ping because it
assumes `payload` is always present:

## Context

This means session keep-alive has never worked — sessions are likely expiring
earlier than expected for users.

## Root Cause

Route registration order in the `initialiseSession` plugin. The parameterised route
`POST /session/{formId}` is registered before `POST /session/keep-alive`, so Hapi
matches keep-alive requests to the wrong handler.


The fix registers `/session/keep-alive` before `/session/{formId}` so Hapi resolves
the specific route first, and adds a null guard on `payload` in the `{formId}` handler
to prevent similar crashes in future.

What is the type of change you are making?

- [ ] Chore or documentation (non-breaking change that does not add functionality)
- [ ] ADR (Architectural Decision Record, non-breaking change that documents or proposes a decision)
- [ ] Refactor (non-breaking change that improves code quality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### PR title

PR titles should be prefixed with the type of change you are making, based on the [README.md#versioning](https://github.com/XGovFormBuilder/digital-form-builder?tab=readme-ov-file#versioning).
This is so that when performing a squash merge, the PR title is automatically used as the commit message.

Have you updated the PR title to match the type of change you are making?

- [ ] Yes
- [ ] No, I need help or guidance

# Testing

## Automated tests

Have you added automated tests?

- [ ] Yes, unit or integration tests
- [ ] Yes, end-to-end (cypress) tests
- [ ] No, tests are not required for this change
- [ ] No, I need help or guidance
- [ ] No (explain why tests are not required or can't be added at this time)

## Manual tests

Have you manually tested your changes?

- [ ] Yes
- [ ] No, manual tests are not required or sufficiently covered by automated tests

Have you attached an example form JSON or snippet for the reviewer in this PR?

- [ ] Yes
- [ ] No, any existing form can be used
- [ ] No, it is not required or not applicable

### Steps to test

1. Step 1
2. Step 2

# Documentation

Have you updated the documentation?

- [ ] Yes, I have updated [./docs](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs) for this change since additional explanation or steps to use/configure the feature is required
- [ ] Yes, I have added or updated an [ADR](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs/adr) for this change since it is large, complex, or has significant architectural implications
- [ ] Yes, I have added inline comments for hard-to-understand areas
- [ ] No, I am not sure if documentation is required
- [ ] No, documentation is not required for this change

# Discussion

Have you discussed this change with the maintainers?

- [ ] Yes, I have discussed this change with the maintainers on slack, email or via GitHub issues
- [ ] Yes, this change is an ADR to help kick-off discussion
- [ ] No, this change is small and does not require discussion
- [ ] No, I am not sure if one is required
