### PR TITLE
feature: Magic link cross session support

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,1 +1,3 @@
-{}
+{
+  "endOfLine": "auto"
+}

--- a/runner/src/server/index.ts
+++ b/runner/src/server/index.ts
@@ -26,6 +26,7 @@ import {
   AddressService,
   CacheService,
   catboxProvider,
+  MagicLinkCacheService,
   NotifyService,
   PayService,
   StatusService,
@@ -109,6 +110,7 @@ async function createServer(routeConfig: RouteConfig) {
 
   server.registerService([
     CacheService,
+    MagicLinkCacheService,
     NotifyService,
     PayService,
     WebhookService,

--- a/runner/src/server/plugins/engine/pageControllers/MagicLinkController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/MagicLinkController.ts
@@ -5,7 +5,6 @@ import { HapiRequest, HapiResponseToolkit } from "server/types";
 import { validateHmac } from "src/server/utils/hmac";
 import Jwt from "@hapi/jwt";
 import config from "server/config";
-import { configureEnginePlugin } from "../configureEnginePlugin";
 
 export class MagicLinkController extends PageController {
   constructor(model, pageDef) {
@@ -19,22 +18,18 @@ export class MagicLinkController extends PageController {
       const requestTime = request.query.request_time;
       const hmacKey = this.model.def.outputs[0].outputConfiguration.hmacKey;
 
-      debugger;
-
       const validation = await validateHmac(email, hmac, requestTime, hmacKey);
 
-     //Outlook safelink consumes magic link - This bypasses it
-     if (!request.headers["user-agent"]) {
-      return h.response("Ignored bot request").code(200);
-    }
+      //Outlook safelink consumes magic link - This bypasses it
+      if (!request.headers["user-agent"]) {
+        return h.response("Ignored bot request").code(200);
+      }
 
-      const { cacheService } = request.services([]);
-
-      const state = await cacheService.getState(request);
+      const { cacheService, magicLinkCacheService } = request.services([]);
 
       //💣 Issue: As the program scales, this will need updating on a per-form basis.
       // Otherwise active on one form, will mark them active on all.
-      const isMagicLinkRecordActive = await cacheService.searchForMagicLinkRecord(
+      const isMagicLinkRecordActive = await magicLinkCacheService.searchForMagicLinkRecord(
         email
       );
 
@@ -42,7 +37,7 @@ export class MagicLinkController extends PageController {
         return h.redirect(`/${this.model.basePath}/expired`).code(302);
       }
 
-      await cacheService.deleteMagicLinkRecord(email);
+      await magicLinkCacheService.deleteMagicLinkRecord(email);
 
       if (!validation.isValid) {
         // Handle different invalid token cases
@@ -50,7 +45,9 @@ export class MagicLinkController extends PageController {
           case "expired":
             return h.redirect(`/${this.model.basePath}/expired`).code(302);
           case "invalid_signature":
-            return h.redirect(`/${this.model.basePath}/incorrect-email`).code(302);
+            return h
+              .redirect(`/${this.model.basePath}/incorrect-email`)
+              .code(302);
           default:
             return h.redirect(`/${this.model.basePath}/error`).code(302);
         }
@@ -64,6 +61,7 @@ export class MagicLinkController extends PageController {
         return this.makePostRouteHandler()(request, h);
       }
 
+      const state = await cacheService.getState(request);
       const viewModel = new SummaryViewModel(this.title, model, state, request);
 
       if (viewModel.endPage) {
@@ -136,11 +134,11 @@ export class MagicLinkController extends PageController {
       const hmacKey = this.model.def.outputs[0].outputConfiguration.hmacKey;
 
       const validation = await validateHmac(email, hmac, requestTime, hmacKey);
-     
+
       //Outlook safelink consumes magic link - This bypasses it
       if (!request.headers["user-agent"]) {
-      return h.response("Ignored bot request").code(200);
-    }
+        return h.response("Ignored bot request").code(200);
+      }
       if (validation.isValid) {
         const token = Jwt.token.generate(
           { email: request.query.email },
@@ -164,6 +162,14 @@ export class MagicLinkController extends PageController {
           isSameSite: "Lax",
         });
       }
+
+      const { magicLinkCacheService } = request.services([]);
+
+      /* Populate the current session with the form state from the session that requested the magic link */
+      await magicLinkCacheService.repopulateFormStateUponMagicLinkReturn(
+        request,
+        hmac
+      );
 
       // Redirect to custom page instead of status
       return redirectTo(request, h, `/${request.params.id}/email-confirmed`);

--- a/runner/src/server/plugins/engine/pageControllers/MagicLinkRedirectController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/MagicLinkRedirectController.ts
@@ -4,16 +4,22 @@ import { HapiRequest, HapiResponseToolkit } from "server/types";
 export class MagicLinkRedirectController extends PageController {
   makeGetRouteHandler() {
     return async (request: HapiRequest, h: HapiResponseToolkit) => {
-    const id = request.params?.id;
-    const forms = request.server?.app?.forms;
-    const model = id && forms?.[id];
-    
-    // Fallback to the default Magic Link config used by CareOBRA
-    // WARNING: This has hardcoded values 
-    // You should define your own magicLinkConfig in your (main) form config   
-    const magicLinkConfig = model?.def?.magicLinkConfig ?? 'magic-link';
-    
-    return h.redirect(`/${magicLinkConfig}/start`).code(302);
+      const id = request.params?.id;
+      const forms = request.server?.app?.forms;
+      const model = id && forms?.[id];
+
+      // Fallback to the default Magic Link config used by CareOBRA
+      // WARNING: This has hardcoded values
+      // You should define your own magicLinkConfig in your (main) form config
+      const magicLinkConfig = model?.def?.magicLinkConfig ?? "magic-link";
+
+      const { magicLinkCacheService } = request.services([]);
+      /* In order to support resume, we need to store the form id */
+      await magicLinkCacheService.saveFormIdBeforeMagicLinkRedirectToAllowResume(
+        request
+      );
+
+      return h.redirect(`/${magicLinkConfig}/start`).code(302);
     };
   }
 }

--- a/runner/src/server/plugins/engine/pageControllers/MagicLinkSubmissionPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/MagicLinkSubmissionPageController.ts
@@ -4,17 +4,22 @@ import { redirectTo } from "../helpers";
 import { HapiRequest, HapiResponseToolkit } from "server/types";
 import { createHmac } from "src/server/utils/hmac";
 import { isAllowedDomain } from "src/server/utils/domain";
+import { ServerStateCookieOptions } from "@hapi/hapi";
 
 // Shared options for cookie settings
-const getCookieOptions = (timeRemaining) => ({
-  ttl: timeRemaining * 1000, // Convert remaining seconds to milliseconds
-  isSecure: true,
-  isHttpOnly: true,
-  encoding: "base64json",
-  path: "/",
-  clearInvalid: false,
-  strictHeader: true,
-});
+const getCookieOptions = (timeRemaining: number) => {
+  const options: ServerStateCookieOptions = {
+    ttl: timeRemaining * 1000, // Convert remaining seconds to milliseconds
+    isSecure: true,
+    isHttpOnly: true,
+    encoding: "base64json",
+    path: "/",
+    clearInvalid: false,
+    strictHeader: true,
+  };
+
+  return options;
+};
 
 // Base controller class containing shared functionality
 export class MagicLinkSubmissionPageController extends PageController {
@@ -85,7 +90,7 @@ export class MagicLinkSubmissionPageController extends PageController {
   makePostRouteHandler() {
     return async (request: HapiRequest, h: HapiResponseToolkit) => {
       this.request = request; // Store request for use in getter methods
-      const { cacheService } = request.services([]);
+      const { cacheService, magicLinkCacheService } = request.services([]);
       const model = this.model;
       const state = await cacheService.getState(request);
       const summaryViewModel = new SummaryViewModel(
@@ -149,7 +154,9 @@ export class MagicLinkSubmissionPageController extends PageController {
       const currentTime = Math.floor(Date.now() / 1000);
 
       // Check if the user already has an active HMAC link
-      const foundHmac = await cacheService.searchForMagicLinkRecord(email);
+      const foundHmac = await magicLinkCacheService.searchForMagicLinkRecord(
+        email
+      );
 
       if (foundHmac && foundHmac.active) {
         const hmacTimestamp = foundHmac.active;
@@ -185,14 +192,22 @@ export class MagicLinkSubmissionPageController extends PageController {
 
       // Store or update the HMAC record
       if (!foundHmac) {
-        await cacheService.createMagicLinkRecord(email, hmac, currentTimestamp);
+        await magicLinkCacheService.createMagicLinkRecord(
+          email,
+          hmac,
+          currentTimestamp
+        );
       } else {
         // Update existing record
-        await cacheService.updateMagicLinkRecord(email, hmac, currentTimestamp);
+        await magicLinkCacheService.updateMagicLinkRecord(
+          email,
+          hmac,
+          currentTimestamp
+        );
       }
 
       // Construct the magic link URL
-      const hmacUrlStart = `/${model.basePath}/return?email=`
+      const hmacUrlStart = `/${model.basePath}/return?email=`;
       const hmacUrl = hmacUrlStart.concat(
         email,
         "&request_time=",
@@ -241,6 +256,12 @@ export class MagicLinkSubmissionPageController extends PageController {
       // Get StatusService and submit the form
       const { statusService } = request.services([]);
       await statusService.outputRequests(request);
+
+      /* In order to allow resume we need to store the current session id, form id and magic link form id */
+      await magicLinkCacheService.saveInformationToAllowMagicLinkResume(
+        request,
+        hmac
+      );
 
       // Redirect to custom page
       return redirectTo(request, h, this.redirectAfterSubmission);

--- a/runner/src/server/services/cacheService.ts
+++ b/runner/src/server/services/cacheService.ts
@@ -42,13 +42,16 @@ export class CacheService {
     this.logger = server.logger;
   }
 
-  async getState(request: HapiRequest): Promise<FormSubmissionState> {
+  async getState(
+    request: Parameters<typeof this.Key>[0]
+  ): Promise<FormSubmissionState> {
     const cached = await this.cache.get(this.Key(request));
+
     return cached || {};
   }
 
   async mergeState(
-    request: HapiRequest,
+    request: Parameters<typeof this.Key>[0],
     value: object,
     nullOverride = true,
     arrayMerge = false
@@ -122,48 +125,10 @@ export class CacheService {
     return this.mergeState(request, { exitState });
   }
 
-  async clearState(request: HapiRequest) {
+  async clearState(request: Parameters<typeof this.Key>[0]) {
     if (request.yar?.id) {
       this.cache.drop(this.Key(request));
     }
-  }
-
-  async createMagicLinkRecord(
-    email: string,
-    hmac: string,
-    currentTimestamp: string
-  ) {
-    const key = email;
-    const value = {
-      hmac: hmac,
-      active: currentTimestamp,
-    };
-    return this.cache.set(key, value, config.sessionTimeout);
-  }
-
-  async updateMagicLinkRecord(
-    email: string,
-    hmac: string,
-    currentTimestamp: string
-  ) {
-    const key = email;
-
-    const value = {
-      hmac: hmac,
-      active: currentTimestamp,
-    };
-    return this.cache.set(key, value, config.sessionTimeout);
-  }
-
-  async searchForMagicLinkRecord(email: string) {
-    const key = email;
-    const emailCached = await this.cache.get(key);
-    return emailCached ?? null;
-  }
-
-  async deleteMagicLinkRecord(email: string) {
-    const key = email;
-    return await this.cache.drop(key);
   }
 
   /**
@@ -173,10 +138,17 @@ export class CacheService {
    * @param request - hapi request object
    * @param additionalIdentifier - appended to the id
    */
-  Key(request: HapiRequest, additionalIdentifier?: ADDITIONAL_IDENTIFIER) {
+  Key(
+    request: {
+      yar: Pick<HapiRequest["yar"], "id">;
+      params: HapiRequest["params"];
+    },
+    additionalIdentifier?: ADDITIONAL_IDENTIFIER
+  ) {
     if (!request?.yar?.id) {
       throw Error("No session ID found");
     }
+
     return {
       segment: partition,
       id: `${request.yar.id}:${request.params.id}${additionalIdentifier ?? ""}`,

--- a/runner/src/server/services/index.ts
+++ b/runner/src/server/services/index.ts
@@ -3,6 +3,7 @@ export { PayService } from "./payService";
 export { NotifyService } from "./notifyService";
 export { EmailService } from "./emailService";
 export { CacheService, catboxProvider } from "./cacheService";
+export { MagicLinkCacheService } from "./magicLinkCacheService";
 export { WebhookService } from "./webhookService";
 export { StatusService } from "./statusService";
 export { AddressService } from "./addressService";

--- a/runner/src/server/services/magicLinkCacheService.ts
+++ b/runner/src/server/services/magicLinkCacheService.ts
@@ -4,14 +4,15 @@ import { HapiRequest, HapiServer } from "../types";
 import { CacheService } from "./cacheService";
 
 export class MagicLinkCacheService {
-  /* This service is responsible for getting, storing or deleting magic link data in the cache. 
+  /* This service is responsible for getting, setting and deleting magic link data in the cache. 
      This service has been registered by {@link createServer}
    */
   cacheService: CacheService;
-  magicLinkRecordCache: TypedCache<MagicLinkRecord>;
 
+  magicLinkRecordCache: TypedCache<MagicLinkRecord>;
   magicLinkFormIdBySessionCache: TypedCache<FormIdBySessionIdRecord>;
   magicLinkReturnDataByHmacCache: TypedCache<ReturnDataByHmacRecord>;
+
   logger: HapiServer["logger"];
 
   ttl = config.sessionTimeout ?? 1000 * 60 * 10; // 10 minutes
@@ -20,11 +21,22 @@ export class MagicLinkCacheService {
     this.logger = server.logger;
 
     const { cacheService } = server.services([]);
-
     this.cacheService = cacheService;
-    this.magicLinkRecordCache = cacheService.cache as typeof this.magicLinkRecordCache;
-    this.magicLinkFormIdBySessionCache = cacheService.cache as typeof this.magicLinkFormIdBySessionCache;
-    this.magicLinkReturnDataByHmacCache = cacheService.cache as typeof this.magicLinkReturnDataByHmacCache;
+
+    this.magicLinkRecordCache = server.cache<MagicLinkRecord>({
+      segment: "magic-link-records",
+      expiresIn: this.ttl,
+    });
+
+    this.magicLinkFormIdBySessionCache = server.cache<FormIdBySessionIdRecord>({
+      segment: "magic-link-form-id-by-session",
+      expiresIn: this.ttl,
+    });
+
+    this.magicLinkReturnDataByHmacCache = server.cache<ReturnDataByHmacRecord>({
+      segment: "magic-link-return-data-by-hmac",
+      expiresIn: this.ttl,
+    });
   }
 
   async createMagicLinkRecord(
@@ -32,7 +44,7 @@ export class MagicLinkCacheService {
     hmac: string,
     currentTimestamp: number
   ) {
-    const key = email;
+    const key = getMagicLinkRecordKey(email);
     const value = {
       hmac: hmac,
       active: currentTimestamp,
@@ -45,7 +57,7 @@ export class MagicLinkCacheService {
     hmac: string,
     currentTimestamp: number
   ) {
-    const key = email;
+    const key = getMagicLinkRecordKey(email);
 
     const value = {
       hmac: hmac,
@@ -55,13 +67,13 @@ export class MagicLinkCacheService {
   }
 
   async searchForMagicLinkRecord(email: string) {
-    const key = email;
+    const key = getMagicLinkRecordKey(email);
     const emailCached = await this.magicLinkRecordCache.get(key);
     return emailCached ?? null;
   }
 
   async deleteMagicLinkRecord(email: string) {
-    const key = email;
+    const key = getMagicLinkRecordKey(email);
     return await this.magicLinkRecordCache.drop(key);
   }
 
@@ -258,15 +270,17 @@ export class MagicLinkCacheService {
 
 type TypedCache<T> = Policy<T, PolicyOptions<T>>;
 
-type MagicLinkRecord = {
-  hmac: string;
-  active: number;
+type MagicLinkRecord = { hmac: string; active: number };
+const getMagicLinkRecordKey = (email: string) => {
+  return `magic_link:${email.toLocaleLowerCase()}`;
 };
 
 type FormIdBySessionIdRecord = { formId: string };
-const getFormIdBySessionIdKey = (sessionId: string) =>
-  `magic_link_form_id_by_session:${sessionId}`;
+const getFormIdBySessionIdKey = (sessionId: string) => {
+  return `magic_link_form_id_by_session:${sessionId.toLocaleLowerCase()}`;
+};
 
 type ReturnDataByHmacRecord = { sessionId: string; formId: string } | undefined;
-const getReturnDataByHmacKey = (hmac: string) =>
-  `magic_link_return_data_by_hmac:${hmac}`;
+const getReturnDataByHmacKey = (hmac: string) => {
+  return `magic_link_return_data_by_hmac:${hmac.toLocaleLowerCase()}`;
+};

--- a/runner/src/server/services/magicLinkCacheService.ts
+++ b/runner/src/server/services/magicLinkCacheService.ts
@@ -1,0 +1,272 @@
+import { Policy, PolicyOptions } from "@hapi/catbox";
+import config from "../config";
+import { HapiRequest, HapiServer } from "../types";
+import { CacheService } from "./cacheService";
+
+export class MagicLinkCacheService {
+  /* This service is responsible for getting, storing or deleting magic link data in the cache. 
+     This service has been registered by {@link createServer}
+   */
+  cacheService: CacheService;
+  magicLinkRecordCache: TypedCache<MagicLinkRecord>;
+
+  magicLinkFormIdBySessionCache: TypedCache<FormIdBySessionIdRecord>;
+  magicLinkReturnDataByHmacCache: TypedCache<ReturnDataByHmacRecord>;
+  logger: HapiServer["logger"];
+
+  ttl = config.sessionTimeout ?? 1000 * 60 * 10; // 10 minutes
+
+  constructor(server: HapiServer) {
+    this.logger = server.logger;
+
+    const { cacheService } = server.services([]);
+
+    this.cacheService = cacheService;
+    this.magicLinkRecordCache = cacheService.cache as typeof this.magicLinkRecordCache;
+    this.magicLinkFormIdBySessionCache = cacheService.cache as typeof this.magicLinkFormIdBySessionCache;
+    this.magicLinkReturnDataByHmacCache = cacheService.cache as typeof this.magicLinkReturnDataByHmacCache;
+  }
+
+  async createMagicLinkRecord(
+    email: string,
+    hmac: string,
+    currentTimestamp: number
+  ) {
+    const key = email;
+    const value = {
+      hmac: hmac,
+      active: currentTimestamp,
+    };
+    return this.magicLinkRecordCache.set(key, value, this.ttl);
+  }
+
+  async updateMagicLinkRecord(
+    email: string,
+    hmac: string,
+    currentTimestamp: number
+  ) {
+    const key = email;
+
+    const value = {
+      hmac: hmac,
+      active: currentTimestamp,
+    };
+    return this.magicLinkRecordCache.set(key, value, this.ttl);
+  }
+
+  async searchForMagicLinkRecord(email: string) {
+    const key = email;
+    const emailCached = await this.magicLinkRecordCache.get(key);
+    return emailCached ?? null;
+  }
+
+  async deleteMagicLinkRecord(email: string) {
+    const key = email;
+    return await this.magicLinkRecordCache.drop(key);
+  }
+
+  async saveFormIdBeforeMagicLinkRedirectToAllowResume(request: HapiRequest) {
+    /* Magic Link Session Resume Step 1: Save the form id before redirecting to the Magic Link form
+       Saves form id by session id, to allow retrieval in the magic link form flow 
+    */
+    const sessionId = request.yar.id;
+
+    /* Form id being redirected to magic link from, for example "ReportAnOutbreak" */
+    const formId = request.params.id as string;
+
+    if (!sessionId || !formId) {
+      request.logger.error("Magic Link: Missing data in step 1", {
+        sessionId,
+        formId,
+      });
+
+      return;
+    }
+
+    /* Set the current form id to allow it to be accessed from the magic link form flow */
+    const key = getFormIdBySessionIdKey(sessionId);
+    await this.magicLinkFormIdBySessionCache.set(key, { formId }, this.ttl);
+  }
+
+  async saveInformationToAllowMagicLinkResume(
+    request: HapiRequest,
+    hmac: string
+  ) {
+    /* Magic Link Session Resume Step 2: Save additional information when sending out the Magic Link
+       In order to be able to re-populate the state after magic link has been clicked without relying on browser state we save the current:
+        - session id (as a new session will be started when opening in a differnt browser)
+        - form id (i.e "ReportAnOutbreak", to know which cache key to retrieve state from)
+      */
+
+    const sessionId = request.yar.id;
+    const magicLinkFormId = request.params.id as string;
+
+    if (!sessionId || !magicLinkFormId) {
+      request.logger.error("Magic Link: Missing data in step 2", {
+        sessionId,
+        magicLinkFormId,
+      });
+
+      return;
+    }
+
+    /* Retrieve form id using the FormIdBySessionIdLookup */
+    const previousFormEntry = await this.magicLinkFormIdBySessionCache.get(
+      getFormIdBySessionIdKey(sessionId)
+    );
+
+    if (!previousFormEntry) {
+      request.logger.error("Magic Link: Missing data in step 2", {
+        sessionId,
+        magicLinkFormId,
+        previousFormEntry,
+      });
+
+      return;
+    }
+
+    /* Save information required to populate state from previous session */
+    await this.magicLinkReturnDataByHmacCache.set(
+      getReturnDataByHmacKey(hmac),
+      {
+        sessionId,
+        formId: previousFormEntry.formId,
+      },
+      this.ttl
+    );
+
+    /* Clear out FormId By Session lookup */
+    await this.magicLinkFormIdBySessionCache.drop(
+      getFormIdBySessionIdKey(sessionId)
+    );
+  }
+
+  async repopulateFormStateUponMagicLinkReturn(
+    request: HapiRequest,
+    hmac: string
+  ) {
+    /* Magic Link Session Resume Step 3:
+       Populate current session with saved data when returning to site from email link, before navigating back to normal form
+     */
+    const magicLinkReturnEntry = await this.magicLinkReturnDataByHmacCache.get(
+      getReturnDataByHmacKey(hmac)
+    );
+
+    if (!magicLinkReturnEntry) {
+      request.logger.error(
+        "Magic Link: Missing data in step 3 (magicLinkReturnEntry undefined)"
+      );
+
+      return;
+    }
+
+    /* Found previous session state */
+    const currentSessionId = request.yar.id;
+    const magicLinkFormId = request.params.id;
+
+    const {
+      sessionId: previousSessionId,
+      formId: previousFormId,
+    } = magicLinkReturnEntry;
+
+    if (!currentSessionId || !previousSessionId || !previousFormId) {
+      request.logger.error("Magic Link: Missing data in step 3", {
+        currentSessionId,
+        previousSessionId,
+        previousFormId,
+      });
+      return;
+    }
+
+    if (currentSessionId === previousSessionId) {
+      /* Continuing in same browser, no need to repopulate previous state */
+      return;
+    }
+
+    /* Continuing in different session (different browser / new browser / new instance / tab)
+       Re-instate form states from previous session 
+    */
+    await this.mergeFormStateFromPreviousSession({
+      previousSessionId,
+      currentSessionId,
+      formId: magicLinkFormId,
+    });
+
+    await this.mergeFormStateFromPreviousSession({
+      previousSessionId,
+      currentSessionId,
+      formId: previousFormId,
+    });
+
+    /* Cleaning up state from previous session */
+    await this.clearFormState(previousSessionId, magicLinkFormId);
+    await this.clearFormState(previousSessionId, previousFormId);
+
+    /* Delete Magic Link Lookup Entry */
+    await this.magicLinkReturnDataByHmacCache.drop(
+      getReturnDataByHmacKey(hmac)
+    );
+  }
+
+  private async mergeFormStateFromPreviousSession({
+    previousSessionId,
+    currentSessionId,
+    formId,
+  }: {
+    previousSessionId: string;
+    currentSessionId: string;
+    formId: string;
+  }) {
+    const previousFormState = await this.getFormState(
+      previousSessionId,
+      formId
+    );
+
+    await this.mergeFormState(currentSessionId, formId, previousFormState);
+  }
+
+  private async getFormState(sessionId: string, formId: string) {
+    return await this.cacheService.getState({
+      params: { id: formId },
+      yar: { id: sessionId },
+    });
+  }
+
+  private async mergeFormState(
+    sessionId: string,
+    formId: string,
+    value: Record<string, any>
+  ) {
+    return await this.cacheService.mergeState(
+      {
+        params: { id: formId },
+        yar: { id: sessionId },
+      },
+      value
+    );
+  }
+
+  private async clearFormState(sessionId: string, formId: string) {
+    if (sessionId && formId) {
+      await this.cacheService.clearState({
+        params: { id: formId },
+        yar: { id: sessionId },
+      });
+    }
+  }
+}
+
+type TypedCache<T> = Policy<T, PolicyOptions<T>>;
+
+type MagicLinkRecord = {
+  hmac: string;
+  active: number;
+};
+
+type FormIdBySessionIdRecord = { formId: string };
+const getFormIdBySessionIdKey = (sessionId: string) =>
+  `magic_link_form_id_by_session:${sessionId}`;
+
+type ReturnDataByHmacRecord = { sessionId: string; formId: string } | undefined;
+const getReturnDataByHmacKey = (hmac: string) =>
+  `magic_link_return_data_by_hmac:${hmac}`;

--- a/runner/src/server/types.ts
+++ b/runner/src/server/types.ts
@@ -13,6 +13,7 @@ import { RateOptions } from "./plugins/rateLimit";
 import {
   CacheService,
   ExitService,
+  MagicLinkCacheService,
   NotifyService,
   PayService,
   StatusService,
@@ -27,6 +28,7 @@ type Services = (
   services: string[]
 ) => {
   cacheService: CacheService;
+  magicLinkCacheService: MagicLinkCacheService;
   notifyService: NotifyService;
   payService: PayService;
   uploadService: UploadService;

--- a/runner/src/server/utils/hmac.ts
+++ b/runner/src/server/utils/hmac.ts
@@ -54,7 +54,10 @@ function formatUnixTimestamp(timestamp: number): string {
 /**
  * Creates an HMAC signature for authentication
  */
-export async function createHmac(email: string, hmacKey: string) {
+export async function createHmac(
+  email: string,
+  hmacKey: string
+): Promise<[string, number, string]> {
   try {
     // Get current timestamp
     const currentTimestamp = Math.floor(Date.now() / 1000);
@@ -85,7 +88,10 @@ export async function createHmac(email: string, hmacKey: string) {
  * making it preferable for cryptographic logic.
  * The other function may benefit from refactoring
  * to separate display logic from core logic. */
-export async function createHmacRaw(message: string, hmacKey: string) {
+export async function createHmacRaw(
+  message: string,
+  hmacKey: string
+): Promise<[string, number, number]> {
   try {
     const currentTimestamp = Math.floor(Date.now() / 1000);
     const dataToHash = message + currentTimestamp;


### PR DESCRIPTION
# Description
Currently the Magic Link functionality does not re-populate data captured in the form prior to the Magic Link part

This resulted in:
- KLS hiding the initially captured data and adding 2 pages to re-capture the data past the magic link verification
- RAO not doing a workaround, and forcing users to always navigate to magic links in the same browser session as the Magic Link was requested

## Context
**A summary of the change**
Capture form data before Magic Link, and re-populate after Magic Link

**A link to the issue this change addresses**
https://ukhsa.atlassian.net/wiki/spaces/IDT/pages/490898788/Magic+link+is+session+dependent

**Motivation and context for the change**
Issue have existed for a long time
Additional forms and usage of Magic Link increasing the severity and teams affected

**Acceptance criteria if you have any**
Testing to verify Magic Links for KLS and RAO forms work as expected both within same session and new session

**A screen recording or screenshots of the feature or change**
N/A

## Changes
Upon magic link redirect, store form id ("kls-enquiries", "ReportAnOutbreak")

Within Magic Link flow upon creating the link, store away further information (current session id, form id, magic link for id)

Upon returning to the form after the Magic Link flow and the session is different then populate saved form state from the previous session and also clean it from previous session.

## Type of change

What is the type of change you are making?

- [ ] Chore or documentation (non-breaking change that does not add functionality)
- [ ] ADR (Architectural Decision Record, non-breaking change that documents or proposes a decision)
- [ ] Refactor (non-breaking change that improves code quality)
- [] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### PR title

PR titles should be prefixed with the type of change you are making, based on the [README.md#versioning](https://github.com/XGovFormBuilder/digital-form-builder?tab=readme-ov-file#versioning).
This is so that when performing a squash merge, the PR title is automatically used as the commit message.

Have you updated the PR title to match the type of change you are making?

- [X] Yes
- [ ] No, I need help or guidance

# Testing
## Automated tests

Have you added automated tests?

- [ ] Yes, unit or integration tests
- [ ] Yes, end-to-end (cypress) tests
- [X] No, tests are not required for this change
- [ ] No, I need help or guidance
- [ ] No (explain why tests are not required or can't be added at this time)

## Manual tests

Have you manually tested your changes?

- [X] Yes
- [ ] No, manual tests are not required or sufficiently covered by automated tests

Have you attached an example form JSON or snippet for the reviewer in this PR?

- [ ] Yes
- [ ] No, any existing form can be used
- [X] No, it is not required or not applicable

### Steps to test

1. Using the RAO form, follow and complete the "You do not need to report flow)
2. Verify the "Setting type" value corresponds to the selection made pre Magic Link flow in the form

# Documentation

Have you updated the documentation?

- [ ] Yes, I have updated [./docs](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs) for this change since additional explanation or steps to use/configure the feature is required
- [ ] Yes, I have added or updated an [ADR](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs/adr) for this change since it is large, complex, or has significant architectural implications
- [X ] Yes, I have added inline comments for hard-to-understand areas
- [] No, I am not sure if documentation is required
- [ ] No, documentation is not required for this change

# Discussion

Have you discussed this change with the maintainers?

- [ ] Yes, I have discussed this change with the maintainers on slack, email or via GitHub issues
- [] Yes, this change is an ADR to help kick-off discussion
- [X ] No, this change is small and does not require discussion
- [ ] No, I am not sure if one is required