### PR TITLE
[NL8 main form only + Platform] - Feature - SRS specific - Grouping Personal Details for improved erros

### DIFF
--- a/model/src/components/component-types.ts
+++ b/model/src/components/component-types.ts
@@ -65,6 +65,15 @@ export const ComponentTypes: ComponentDef[] = [
     schema: {},
   },
   {
+    name: "ContactDetailsCollection",
+    type: "ContactDetailsCollection",
+    title: "Contact details collection",
+    subType: "field",
+    hint: "",
+    options: {},
+    schema: {},
+  },
+  {
     name: "DateTimePartsField",
     type: "DateTimePartsField",
     title: "Date time parts field",

--- a/model/src/components/types.ts
+++ b/model/src/components/types.ts
@@ -6,6 +6,7 @@ export enum ComponentTypeEnum {
   TimeField = "TimeField",
   DateTimeField = "DateTimeField",
   DatePartsField = "DatePartsField",
+  ContactDetailsCollection = "ContactDetailsCollection",
   MonthYearField = "MonthYearField",
   DateTimePartsField = "DateTimePartsField",
   SelectField = "SelectField",
@@ -36,6 +37,7 @@ export type ComponentType =
   | "DateTimeField"
   | "MonthYearField"
   | "DatePartsField"
+  | "ContactDetailsCollection"
   | "DateTimePartsField"
   | "SelectField"
   | "AutocompleteField"
@@ -262,6 +264,9 @@ export interface DateTimeFieldComponent extends DateFieldBase {
 export interface DatePartsFieldFieldComponent extends DateFieldBase {
   type: "DatePartsField";
 }
+export interface ContactDetailsCollectionComponent extends DateFieldBase {
+  type: "ContactDetailsCollection";
+}
 
 export interface MonthYearFieldComponent extends DateFieldBase {
   type: "MonthYearField";
@@ -338,6 +343,7 @@ export type ComponentDef =
   | CheckboxesFieldComponent
   | DateFieldComponent
   | DatePartsFieldFieldComponent
+  | ContactDetailsCollectionComponent
   | MonthYearFieldComponent
   | DateTimeFieldComponent
   | DateTimePartsFieldComponent

--- a/runner/src/server/forms/close-contact-form-nl8.json
+++ b/runner/src/server/forms/close-contact-form-nl8.json
@@ -184,62 +184,26 @@
           "hint": "For example, 27 3 2005"
         },
         {
-          "name": "VnYxYi",
+          "name": "mWvTOY",
           "options": {},
-          "type": "Html",
-          "content": "<br/><h2 class='govuk-heading-m'>Contact details</h2>"
+          "type": "ContactDetailsCollection",
+          "title": "Contact Details"
         },
         {
-          "name": "dieFHl",
-          "options": {},
-          "type": "Html",
-          "content": "<span id='at-least-one' class='govuk-!-display-none'>Provide a mobile number, email or both</span>"
-        },
-        {
-          "name": "mobile_number",
-          "options": {
-            "required": false,
-            "optionalText": false,
-            "customValidationMessages": {
-              "string.pattern.base": "Enter a mobile number in the correct format"
-            }
-          },
           "type": "TelephoneNumberField",
-          "title": "Mobile number",
-          "hint": "For example, 07700 900999",
-          "schema": {
-            "regex": "^(((\\+44\\s?\\d{4}|\\(?0\\d{4}\\)?)\\s?\\d{3}\\s?\\d{3})|((\\+44\\s?\\d{3}|\\(?0\\d{3}\\)?)\\s?\\d{3}\\s?\\d{4})|((\\+44\\s?\\d{2}|\\(?0\\d{2}\\)?)\\s?\\d{4}\\s?\\d{4}))(\\s?#(\\d{4}|\\d{3}))?$"
-          }
-        },
-        {
           "name": "landline_number",
-          "options": { "required": false },
-          "type": "TelephoneNumberField",
-          "title": "Landline number",
-          "hint": "For example, 020 7123 4567",
-          "schema": {
-            "regex": "^0([1-6][\\s\\d]{8,12})$"
-          }
-        },
-        {
-          "name": "email_address",
+          "title": "Example Landline number",
+          "hint": "For example, 01632 960999",
           "options": {
             "required": false,
             "optionalText": false,
             "customValidationMessages": {
-              "string.empty": "Enter a valid email address",
-              "string.pattern.base": "Enter a valid email address"
+              "string.pattern.base": "Enter a valid landline number"
+            },
+            "schema": {
+              "regex": "^0([1-6][\\s\\d]{8,12})$"
             }
-          },
-          "type": "EmailAddressField",
-          "title": "Email address",
-          "hint": "For example, sarah.philips@example.com"
-        },
-        {
-          "name": "ValidationScript",
-          "options": {},
-          "type": "Html",
-          "content": "<script>document.querySelector(\"form[enctype='multipart/form-data']\").addEventListener(\"submit\",function(e){if(document.getElementById(\"mobile_number\").value===\"\"&&document.getElementById(\"email_address\").value===\"\"){e.preventDefault();document.getElementById(\"at-least-one\").className=\"govuk-error-message\";document.getElementById(\"at-least-one\").setAttribute(\"role\",\"alert\");location.href=\"#at-least-one\"}else{window.location.hash=\"\"}});</script>"
+          }
         }
       ],
       "next": [{ "path": "/check-your-details" }],

--- a/runner/src/server/forms/close-contact-form-nl8.json
+++ b/runner/src/server/forms/close-contact-form-nl8.json
@@ -188,22 +188,6 @@
           "options": {},
           "type": "ContactDetailsCollection",
           "title": "Contact Details"
-        },
-        {
-          "type": "TelephoneNumberField",
-          "name": "landline_number",
-          "title": "Example Landline number",
-          "hint": "For example, 01632 960999",
-          "options": {
-            "required": false,
-            "optionalText": false,
-            "customValidationMessages": {
-              "string.pattern.base": "Enter a valid landline number"
-            },
-            "schema": {
-              "regex": "^0([1-6][\\s\\d]{8,12})$"
-            }
-          }
         }
       ],
       "next": [{ "path": "/check-your-details" }],

--- a/runner/src/server/plugins/engine/components/ContactDetailsCollection.ts
+++ b/runner/src/server/plugins/engine/components/ContactDetailsCollection.ts
@@ -36,20 +36,31 @@ export class ContactDetailsCollection extends FormComponent {
     this.children = new ComponentCollection(
       [
         {
-          type: "TelephoneNumberField",
           name: "mobile_number",
-          title: "Mobile number",
-          hint: "For example, 07700 900999",
           options: {
             required: false,
             optionalText: false,
             customValidationMessages: {
-              "string.pattern.base": "Enter a valid UK mobile number",
+              "string.pattern.base":
+                "Enter a mobile number in the correct format",
             },
           },
+          type: "TelephoneNumberField",
+          title: "Mobile number",
+          hint: "For example, 07700 900999",
           schema: {
             regex:
-              "(?!0{5,})(((\\+44\\s?(?!4|6)\\d{4}|\\(?0(?!4|6)\\d{4}\\)?)\\s?\\d{3}\\s?\\d{3})|((\\+44\\s?(?!4|6)\\d{3}|\\(?0(?!4|6)\\d{3}\\)?)\\s?\\d{3}\\s?\\d{4})|((\\+44\\s?(?!4|6)\\d{2}|\\(?0(?!4|6)\\d{2}\\)?)\\s?\\d{4}\\s?\\d{4}))(\\s?\\#(\\d{4}|\\d{3}))?",
+              "^(((\\+44\\s?\\d{4}|\\(?0\\d{4}\\)?)\\s?\\d{3}\\s?\\d{3})|((\\+44\\s?\\d{3}|\\(?0\\d{3}\\)?)\\s?\\d{3}\\s?\\d{4})|((\\+44\\s?\\d{2}|\\(?0\\d{2}\\)?)\\s?\\d{4}\\s?\\d{4}))(\\s?#(\\d{4}|\\d{3}))?$",
+          },
+        },
+        {
+          name: "landline_number",
+          options: { required: false, optionalText: false },
+          type: "TelephoneNumberField",
+          title: "Landline number",
+          hint: "For example, 020 7123 4567",
+          schema: {
+            regex: "^0([1-6][\\s\\d]{8,12})$",
           },
         },
         {
@@ -66,13 +77,10 @@ export class ContactDetailsCollection extends FormComponent {
           },
         },
         // Hidden carrier field for the "at least one" cross-field rule.
-        // Name MUST match this.name — the synthetic key in getFormSchemaKeys
         // attaches the custom validator to this name, and Joi only runs
         // validators on keys present in the payload. Removing this field
         // silently disables the cross-field check.
         {
-          // Shouldn't this be a bool ?
-          // I believe this is used just to trigger the cross-field validation rule
           type: "TextField",
           name: this.name,
           title: "Contact details",

--- a/runner/src/server/plugins/engine/components/ContactDetailsCollection.ts
+++ b/runner/src/server/plugins/engine/components/ContactDetailsCollection.ts
@@ -1,0 +1,144 @@
+import { Schema } from "joi";
+import { InputFieldsComponentsDef } from "@xgovformbuilder/model";
+import Joi from "joi";
+
+import { optionalText } from "./constants";
+import { FormComponent } from "./FormComponent";
+import { ComponentCollection } from "./ComponentCollection";
+import {
+  FormData,
+  FormPayload,
+  FormSubmissionErrors,
+  FormSubmissionState,
+} from "../types";
+import { FormModel } from "../models";
+
+export class ContactDetailsCollection extends FormComponent {
+  children: ComponentCollection;
+
+  constructor(def: InputFieldsComponentsDef, model: FormModel) {
+    super(def, model);
+    const options: any = this.options;
+
+    this.children = new ComponentCollection(
+      [
+        {
+          type: "TelephoneNumberField",
+          name: "mobile_number",
+          title: "Mobile number",
+          hint: "For example, 07700 900999",
+          options: {
+            required: options.required,
+            customValidationMessages: {
+              "string.empty": "Enter a mobile number",
+              "string.pattern.base": "Enter a valid UK mobile number",
+            },
+          },
+        },
+        {
+          type: "TelephoneNumberField",
+          name: "landline_number",
+          title: "Landline number",
+          hint: "For example, 01632 960999",
+          options: {
+            required: false, // landline is optional
+            optionalText: true,
+            customValidationMessages: {
+              "string.pattern.base": "Enter a valid landline number",
+            },
+          },
+        },
+        {
+          type: "EmailAddressField",
+          name: "email_address",
+          title: "Email address",
+          hint: "For example, name@example.com",
+          options: {
+            required: options.required,
+            customValidationMessages: {
+              "string.empty": "Enter an email address",
+              "string.email": "Enter an email address in the correct format",
+            },
+          },
+        },
+      ] as any,
+      model
+    );
+
+    // Build a state schema that validates the whole contact details object
+    this.stateSchema = Joi.object({
+      mobile_number: Joi.string().required(),
+      landline_number: Joi.string().optional().allow("", null),
+      email_address: Joi.string().email().required(),
+    });
+  }
+
+  // Expose child field keys for form-level validation
+  getFormSchemaKeys() {
+    return this.children.getFormSchemaKeys();
+  }
+
+  // Expose a single namespaced key for state-level validation
+  getStateSchemaKeys() {
+    return { [this.name]: this.stateSchema as Schema };
+  }
+
+  // Unpack stored state back into individual form fields
+  getFormDataFromState(state: FormSubmissionState) {
+    const name = this.name;
+    const value = state[name] ?? {};
+    return {
+      mobile_number: value.mobile_number ?? "",
+      landline_number: value.landline_number ?? "",
+      email_address: value.email_address ?? "",
+    };
+  }
+
+  // Pack submitted form fields back into a single state value
+  getStateValueFromValidForm(payload: FormPayload) {
+    return {
+      mobile_number: payload["mobile_number"] || null,
+      landline_number: payload["landline_number"] || null,
+      email_address: payload["email_address"] || null,
+    };
+  }
+
+  // Human-readable summary for review pages
+  getDisplayStringFromState(state: FormSubmissionState) {
+    const value = state[this.name];
+    if (!value) return "";
+    const parts = [
+      value.mobile_number,
+      value.landline_number,
+      value.email_address,
+    ].filter(Boolean);
+    return parts.join(", ");
+  }
+
+  getViewModel(formData: FormData, errors: FormSubmissionErrors) {
+    const viewModel = super.getViewModel(formData, errors);
+
+    const componentViewModels = this.children
+      .getViewModel(formData, errors)
+      .map((vm) => vm.model);
+
+    componentViewModels.forEach((componentViewModel) => {
+      componentViewModel.label = componentViewModel.label?.text?.replace(
+        optionalText,
+        ""
+      ) as any;
+
+      if (componentViewModel.errorMessage) {
+        componentViewModel.classes += " govuk-input--error";
+      }
+    });
+
+    return {
+      ...viewModel,
+      fieldset: {
+        legend: viewModel.label,
+      },
+      items: (componentViewModels as unknown) as ListItem[],
+    };
+  }
+}

--- a/runner/src/server/plugins/engine/components/ContactDetailsCollection.ts
+++ b/runner/src/server/plugins/engine/components/ContactDetailsCollection.ts
@@ -12,7 +12,10 @@ import {
   FormSubmissionState,
 } from "../types";
 import { FormModel } from "../models";
+import { ListItem } from "./types"; // check this
 
+// TODO FIX IT SO IT CORRECTLY DISPLAYS THE INTERNAL NESTED COMPONENTS
+// SHOULD CORRECTLY DISPLAY
 export class ContactDetailsCollection extends FormComponent {
   children: ComponentCollection;
 
@@ -28,35 +31,42 @@ export class ContactDetailsCollection extends FormComponent {
           title: "Mobile number",
           hint: "For example, 07700 900999",
           options: {
-            required: options.required,
+            required: false,
+            optionalText: false,
             customValidationMessages: {
-              "string.empty": "Enter a mobile number",
               "string.pattern.base": "Enter a valid UK mobile number",
             },
           },
-        },
-        {
-          type: "TelephoneNumberField",
-          name: "landline_number",
-          title: "Landline number",
-          hint: "For example, 01632 960999",
-          options: {
-            required: false, // landline is optional
-            optionalText: true,
-            customValidationMessages: {
-              "string.pattern.base": "Enter a valid landline number",
-            },
+          schema: {
+            regex:
+              "(?!0{5,})(((\\+44\\s?(?!4|6)\\d{4}|\\(?0(?!4|6)\\d{4}\\)?)\\s?\\d{3}\\s?\\d{3})|((\\+44\\s?(?!4|6)\\d{3}|\\(?0(?!4|6)\\d{3}\\)?)\\s?\\d{3}\\s?\\d{4})|((\\+44\\s?(?!4|6)\\d{2}|\\(?0(?!4|6)\\d{2}\\)?)\\s?\\d{4}\\s?\\d{4}))(\\s?\\#(\\d{4}|\\d{3}))?",
           },
         },
+        // {
+        //   type: "TelephoneNumberField",
+        //   name: "landline_number", // I don't know why the titles to the componets in my collection are not being picked up
+        //   title: "Landline number",
+        //   hint: "For example, 01632 960999",
+        //   options: {
+        //     required: false, // landline is optional
+        //     optionalText: false,
+        //     customValidationMessages: {
+        //       "string.pattern.base": "Random incorrect value",
+        //     },
+        //     schema: {
+        //       regex: "^0([1-6][\\s\\d]{8,12})$",
+        //     },
+        //   },
+        // },
         {
           type: "EmailAddressField",
           name: "email_address",
           title: "Email address",
           hint: "For example, name@example.com",
           options: {
-            required: options.required,
+            required: false,
+            optionalText: false,
             customValidationMessages: {
-              "string.empty": "Enter an email address",
               "string.email": "Enter an email address in the correct format",
             },
           },
@@ -66,24 +76,66 @@ export class ContactDetailsCollection extends FormComponent {
     );
 
     // Build a state schema that validates the whole contact details object
-    this.stateSchema = Joi.object({
-      mobile_number: Joi.string().required(),
-      landline_number: Joi.string().optional().allow("", null),
-      email_address: Joi.string().email().required(),
+    let stateSchema = Joi.object({
+      mobile_number: Joi.string().empty(["", null]),
+      landline_number: Joi.string().empty(["", null]),
+      email_address: Joi.string().email().empty(["", null]),
     });
+
+    // const isRequired = (this.options as any).required !== false;
+    // TODO: CHANGE THIS BACK TO CHECKING THE OPTION, NOT HARD-CODED. For now, hard-code to required to unblock development of the new summary page, which needs the display string to be generated for the contact details collection.
+    const isRequired = true;
+
+    if (isRequired) {
+      stateSchema = stateSchema.or("mobile_number", "email_address").messages({
+        "object.missing":
+          (this.options as any).customValidationMessages?.["any.required"] ??
+          "Enter a mobile number or email address so we can contact you",
+      });
+    }
+
+    this.stateSchema = stateSchema;
   }
 
-  // Expose child field keys for form-level validation
   getFormSchemaKeys() {
-    return this.children.getFormSchemaKeys();
+    console.log("[ContactDetails] === getFormSchemaKeys ===");
+    const childrenKeys = this.children.getFormSchemaKeys();
+    const isRequired = true; // (this.options as any).required !== false;
+
+    if (!isRequired) {
+      return childrenKeys;
+    }
+
+    return {
+      ...childrenKeys,
+      [this.name]: Joi.any()
+        .default(null)
+        .custom((_value, helpers) => {
+          const root = helpers.state.ancestors[0] as any;
+
+          const hasMobile =
+            root?.mobile_number && String(root.mobile_number).trim() !== "";
+          const hasEmail =
+            root?.email_address && String(root.email_address).trim() !== "";
+          console.log("hasMobile →", hasMobile);
+          console.log("hasEmail →", hasEmail);
+          if (!hasMobile && !hasEmail) {
+            return helpers.error("any.invalid");
+          }
+          return _value;
+        })
+        .messages({
+          "any.invalid":
+            (this.options as any).customValidationMessages?.["any.required"] ??
+            "Provide a mobile number, email or both", // Change this error to have a name so it can be passed in
+        }),
+    };
   }
 
-  // Expose a single namespaced key for state-level validation
   getStateSchemaKeys() {
     return { [this.name]: this.stateSchema as Schema };
   }
 
-  // Unpack stored state back into individual form fields
   getFormDataFromState(state: FormSubmissionState) {
     const name = this.name;
     const value = state[name] ?? {};
@@ -106,6 +158,7 @@ export class ContactDetailsCollection extends FormComponent {
   // Human-readable summary for review pages
   getDisplayStringFromState(state: FormSubmissionState) {
     const value = state[this.name];
+
     if (!value) return "";
     const parts = [
       value.mobile_number,
@@ -118,15 +171,22 @@ export class ContactDetailsCollection extends FormComponent {
   getViewModel(formData: FormData, errors: FormSubmissionErrors) {
     const viewModel = super.getViewModel(formData, errors);
 
+    console.log("[ContactDetails] === getViewModel ===");
+    console.log("  this.title →", JSON.stringify(this.title));
+    console.log("  this.options →", JSON.stringify(this.options));
+    console.log("  super viewModel.label →", JSON.stringify(viewModel.label));
+    console.log("  super viewModel.hint →", JSON.stringify(viewModel.hint));
+
     const componentViewModels = this.children
       .getViewModel(formData, errors)
       .map((vm) => vm.model);
 
     componentViewModels.forEach((componentViewModel) => {
-      componentViewModel.label = componentViewModel.label?.text?.replace(
-        optionalText,
-        ""
-      ) as any;
+      // I AM NOT SURE WHAT THIS BIT IS DOING
+      // componentViewModel.label = componentViewModel.label?.text?.replace(
+      //   optionalText,
+      //   ""
+      // ) as any;
 
       if (componentViewModel.errorMessage) {
         componentViewModel.classes += " govuk-input--error";
@@ -135,9 +195,7 @@ export class ContactDetailsCollection extends FormComponent {
 
     return {
       ...viewModel,
-      fieldset: {
-        legend: viewModel.label,
-      },
+      fieldset: { legend: viewModel.label },
       items: (componentViewModels as unknown) as ListItem[],
     };
   }

--- a/runner/src/server/plugins/engine/components/ContactDetailsCollection.ts
+++ b/runner/src/server/plugins/engine/components/ContactDetailsCollection.ts
@@ -2,7 +2,6 @@ import { Schema } from "joi";
 import { InputFieldsComponentsDef } from "@xgovformbuilder/model";
 import Joi from "joi";
 
-import { optionalText } from "./constants";
 import { FormComponent } from "./FormComponent";
 import { ComponentCollection } from "./ComponentCollection";
 import {
@@ -12,16 +11,27 @@ import {
   FormSubmissionState,
 } from "../types";
 import { FormModel } from "../models";
-import { ListItem } from "./types"; // check this
+import { ListItem } from "./types";
 
-// TODO FIX IT SO IT CORRECTLY DISPLAYS THE INTERNAL NESTED COMPONENTS
-// SHOULD CORRECTLY DISPLAY
+/**
+ * Composite component rendering mobile number + email + landline inside a single fieldset,
+ * with a cross-field rule: at least one of the mobile or email must be provided (when the
+ * component is required).
+ *
+ * The "at least one" rule is enforced in Pass 1 (form schema) via a synthetic
+ * key on `this.name`. A hidden <input> with the same name is rendered alongside
+ * the visible inputs so that key is always present in the payload — Joi only
+ * runs validators on keys that exist in the input being validated.
+ */
 export class ContactDetailsCollection extends FormComponent {
   children: ComponentCollection;
 
+  // Joi schema for the cross-field "at least one of mobile/email" rule.
+  // Attached to the synthetic [this.name] key in the form schema.
+  private contactRequiredSchema: Joi.Schema;
+
   constructor(def: InputFieldsComponentsDef, model: FormModel) {
     super(def, model);
-    const options: any = this.options;
 
     this.children = new ComponentCollection(
       [
@@ -42,22 +52,6 @@ export class ContactDetailsCollection extends FormComponent {
               "(?!0{5,})(((\\+44\\s?(?!4|6)\\d{4}|\\(?0(?!4|6)\\d{4}\\)?)\\s?\\d{3}\\s?\\d{3})|((\\+44\\s?(?!4|6)\\d{3}|\\(?0(?!4|6)\\d{3}\\)?)\\s?\\d{3}\\s?\\d{4})|((\\+44\\s?(?!4|6)\\d{2}|\\(?0(?!4|6)\\d{2}\\)?)\\s?\\d{4}\\s?\\d{4}))(\\s?\\#(\\d{4}|\\d{3}))?",
           },
         },
-        // {
-        //   type: "TelephoneNumberField",
-        //   name: "landline_number", // I don't know why the titles to the componets in my collection are not being picked up
-        //   title: "Landline number",
-        //   hint: "For example, 01632 960999",
-        //   options: {
-        //     required: false, // landline is optional
-        //     optionalText: false,
-        //     customValidationMessages: {
-        //       "string.pattern.base": "Random incorrect value",
-        //     },
-        //     schema: {
-        //       regex: "^0([1-6][\\s\\d]{8,12})$",
-        //     },
-        //   },
-        // },
         {
           type: "EmailAddressField",
           name: "email_address",
@@ -71,64 +65,67 @@ export class ContactDetailsCollection extends FormComponent {
             },
           },
         },
+        // Hidden carrier field for the "at least one" cross-field rule.
+        // Name MUST match this.name — the synthetic key in getFormSchemaKeys
+        // attaches the custom validator to this name, and Joi only runs
+        // validators on keys present in the payload. Removing this field
+        // silently disables the cross-field check.
+        {
+          // Shouldn't this be a bool ?
+          // I believe this is used just to trigger the cross-field validation rule
+          type: "TextField",
+          name: this.name,
+          title: "Contact details",
+          schema: {},
+          options: {
+            classes: "govuk-!-display-none",
+            hideTitle: true,
+            disableChangingFromSummary: true,
+            allowPrePopulationOverwrite: true,
+            required: false,
+          },
+        },
       ] as any,
       model
     );
 
-    // Build a state schema that validates the whole contact details object
-    let stateSchema = Joi.object({
+    // State schema (Pass 2) — shape only
+    this.stateSchema = Joi.object({
       mobile_number: Joi.string().empty(["", null]),
-      landline_number: Joi.string().empty(["", null]),
-      email_address: Joi.string().email().empty(["", null]),
+      email_address: Joi.string().empty(["", null]).email(),
     });
 
-    // const isRequired = (this.options as any).required !== false;
-    // TODO: CHANGE THIS BACK TO CHECKING THE OPTION, NOT HARD-CODED. For now, hard-code to required to unblock development of the new summary page, which needs the display string to be generated for the contact details collection.
-    const isRequired = true;
-
-    if (isRequired) {
-      stateSchema = stateSchema.or("mobile_number", "email_address").messages({
-        "object.missing":
-          (this.options as any).customValidationMessages?.["any.required"] ??
+    // Cross-field rule enforcing "at least one of mobile/email" when the component is required.
+    // Injected as callback on the synthetic [this.name] key in getFormSchemaKeys.
+    this.contactRequiredSchema = Joi.any()
+      .custom((value, helpers) => {
+        const root = helpers.state.ancestors[0] as any;
+        const hasMobile =
+          root?.mobile_number && String(root.mobile_number).trim() !== "";
+        const hasEmail =
+          root?.email_address && String(root.email_address).trim() !== "";
+        if (!hasMobile && !hasEmail) {
+          return helpers.error("any.invalid");
+        }
+        return value;
+      })
+      .messages({
+        "any.invalid":
+          (this.options as any)?.customValidationMessages?.["any.required"] ??
           "Enter a mobile number or email address so we can contact you",
       });
-    }
-
-    this.stateSchema = stateSchema;
   }
 
   getFormSchemaKeys() {
-    console.log("[ContactDetails] === getFormSchemaKeys ===");
+    // Inherit child keys, then add the synthetic key for the cross-field rule.
     const childrenKeys = this.children.getFormSchemaKeys();
-    const isRequired = true; // (this.options as any).required !== false;
+    const isRequired = (this.options as any)?.required !== false;
 
-    if (!isRequired) {
-      return childrenKeys;
-    }
+    if (!isRequired) return childrenKeys;
 
     return {
       ...childrenKeys,
-      [this.name]: Joi.any()
-        .default(null)
-        .custom((_value, helpers) => {
-          const root = helpers.state.ancestors[0] as any;
-
-          const hasMobile =
-            root?.mobile_number && String(root.mobile_number).trim() !== "";
-          const hasEmail =
-            root?.email_address && String(root.email_address).trim() !== "";
-          console.log("hasMobile →", hasMobile);
-          console.log("hasEmail →", hasEmail);
-          if (!hasMobile && !hasEmail) {
-            return helpers.error("any.invalid");
-          }
-          return _value;
-        })
-        .messages({
-          "any.invalid":
-            (this.options as any).customValidationMessages?.["any.required"] ??
-            "Provide a mobile number, email or both", // Change this error to have a name so it can be passed in
-        }),
+      [this.name]: this.contactRequiredSchema,
     };
   }
 
@@ -137,59 +134,47 @@ export class ContactDetailsCollection extends FormComponent {
   }
 
   getFormDataFromState(state: FormSubmissionState) {
-    const name = this.name;
-    const value = state[name] ?? {};
+    const value = state[this.name] ?? {};
     return {
       mobile_number: value.mobile_number ?? "",
-      landline_number: value.landline_number ?? "",
       email_address: value.email_address ?? "",
     };
   }
 
-  // Pack submitted form fields back into a single state value
   getStateValueFromValidForm(payload: FormPayload) {
     return {
       mobile_number: payload["mobile_number"] || null,
-      landline_number: payload["landline_number"] || null,
       email_address: payload["email_address"] || null,
     };
   }
 
-  // Human-readable summary for review pages
   getDisplayStringFromState(state: FormSubmissionState) {
     const value = state[this.name];
-
     if (!value) return "";
-    const parts = [
-      value.mobile_number,
-      value.landline_number,
-      value.email_address,
-    ].filter(Boolean);
-    return parts.join(", ");
+    return [value.mobile_number, value.email_address]
+      .filter(Boolean)
+      .join(", ");
   }
 
   getViewModel(formData: FormData, errors: FormSubmissionErrors) {
     const viewModel = super.getViewModel(formData, errors);
 
-    console.log("[ContactDetails] === getViewModel ===");
-    console.log("  this.title →", JSON.stringify(this.title));
-    console.log("  this.options →", JSON.stringify(this.options));
-    console.log("  super viewModel.label →", JSON.stringify(viewModel.label));
-    console.log("  super viewModel.hint →", JSON.stringify(viewModel.hint));
+    // Filter out error from hidden field
+    const childErrors: FormSubmissionErrors | undefined = errors
+      ? {
+          ...errors,
+          errorList:
+            errors.errorList?.filter((e) => e.name !== this.name) ?? [],
+        }
+      : errors;
 
     const componentViewModels = this.children
-      .getViewModel(formData, errors)
+      .getViewModel(formData, childErrors)
       .map((vm) => vm.model);
 
-    componentViewModels.forEach((componentViewModel) => {
-      // I AM NOT SURE WHAT THIS BIT IS DOING
-      // componentViewModel.label = componentViewModel.label?.text?.replace(
-      //   optionalText,
-      //   ""
-      // ) as any;
-
-      if (componentViewModel.errorMessage) {
-        componentViewModel.classes += " govuk-input--error";
+    componentViewModels.forEach((cvm: any) => {
+      if (cvm.errorMessage) {
+        cvm.classes = `${cvm.classes ?? ""} govuk-input--error`.trim();
       }
     });
 

--- a/runner/src/server/plugins/engine/components/index.ts
+++ b/runner/src/server/plugins/engine/components/index.ts
@@ -11,6 +11,7 @@ export { ComponentCollection } from "./ComponentCollection";
 // export { ConditionalFormComponent } from "./ConditionalFormComponent";
 export { DateField } from "./DateField";
 export { DatePartsField } from "./DatePartsField";
+export { ContactDetailsCollection } from "./ContactDetailsCollection";
 export { DateTimeField } from "./DateTimeField";
 export { DateTimePartsField } from "./DateTimePartsField";
 export { Details } from "./Details";

--- a/runner/src/server/plugins/engine/views/components/contactdetailscollection.html
+++ b/runner/src/server/plugins/engine/views/components/contactdetailscollection.html
@@ -1,0 +1,38 @@
+{% from "input/macro.njk" import govukInput %}
+{% from "fieldset/macro.njk" import govukFieldset %}
+
+{% macro ContactDetailsCollection(component) %}
+  <div class="govuk-form-group {{ 'govuk-form-group--error' if component.model.errorMessage }}">
+    {% call govukFieldset({
+      legend: {
+        text: component.model.fieldset.legend.text,
+        classes: "govuk-fieldset__legend--m"
+      }
+    }) %}
+      {% if component.model.hint %}
+        <div class="govuk-hint">{{ component.model.hint.html | safe }}</div>
+      {% endif %}
+
+      {% if component.model.errorMessage %}
+        <p id="{{ component.model.id }}-error" class="govuk-error-message">
+          <span class="govuk-visually-hidden">Error:</span>
+          {{ component.model.errorMessage.text }}
+        </p>
+      {% endif %}
+
+      {% for item in component.model.items %}
+        {{ govukInput({
+          label: item.label,
+          hint: item.hint,
+          id: item.id,
+          name: item.name,
+          value: item.value,
+          type: item.type,
+          classes: item.classes,
+          autocomplete: item.autocomplete,
+          errorMessage: item.errorMessage
+        }) }}
+      {% endfor %}
+    {% endcall %}
+  </div>
+{% endmacro %}


### PR DESCRIPTION
## Cross-field validation in the Close Contact form

### Background

The contact-details cross-field rule (at least one of *mobile* or *email* must be provided) was previously enforced by injecting an HTML `<script>` tag into the page. This caused three problems:

- **Accessibility.** The error didn't follow GOV.UK Design System patterns: it didn't appear in the page-level error summary, and was not properly associated with the contact-details fieldset for screen-reader users.
- **Security.** Injecting markup from client-side script bypasses the templating layer's escaping. Even if only fixed strings were injected today, the pattern leaves the door open to a future change introducing a cross-site scripting vulnerability.
- **Error precedence.** When the rule fired, it suppressed every other error on the page — so users had to fix the contact-details error first, resubmit, and only then discover the rest. One round of feedback became several.

### Why the workaround existed

The X-Gov form runner has no built-in mechanism for cross-field validation, at either the component or page level. The original developer reached for client-side script because the framework's extension points didn't obviously cover the case.

### The fix

I implemented the rule as a new composite component (`ContactDetailsCollection`) that wraps the existing mobile, email, and landline fields and feeds its rule into the runner's standard validation pipeline. As a result:

- Validation runs server-side, in the same pass as every other field.
- Errors appear in the page-level summary alongside other errors, with the correct anchor links and styling.
- The error is also rendered inline above the fieldset legend, matching govuk-frontend patterns.
- No client-side script or HTML injection is involved.


### Downstream Only Change justification
I scoped this change as downstream-only because the logic is specific to SRS: it moves SRS-specific behaviour from the client to the server, where it belongs, but does not extend the upstream framework.
I considered building a generalised cross-field validation feature that could be contributed back to X-Gov, but after discussion with the X-Gov collaboration team I decided against it. There is no current demand for the feature from other services, and the platform is not designed with service-specific JavaScript in mind, so a generic solution would be speculative.
That said, this work does serve as a useful reference for UKHSA: it shows how teams can make small, well-contained changes to extend the form runner's behaviour without modifying the framework itself.

### Scenarios verified

1. EMPTY PAGE SUMBISSION 
<img width="304" height="523" alt="(OLD)empty form submssion " src="https://github.com/user-attachments/assets/0ee3df3e-5c64-4968-b841-36f30402cff9" />

<img width="347" height="621" alt="empty form submission new" src="https://github.com/user-attachments/assets/9671bb20-34fd-4661-bc8a-2a8da8e09c23" />


2. SUBMISSION WITH NO CONTACT DETAILS 
<img width="358" height="513" alt="2" src="https://github.com/user-attachments/assets/cd4c0f01-5951-451a-9b3d-dc0c85186494" />
<img width="279" height="476" alt="2(OLD)" src="https://github.com/user-attachments/assets/08a480ca-0951-47a4-b1af-4879908389e6" />


3. SUBMISSION WITH SPECIFIC ERROR IN CONTACT DETAILS
<img width="448" height="534" alt="3" src="https://github.com/user-attachments/assets/2984fdbd-e357-4208-bfd8-f7662851e772" />
<img width="347" height="512" alt="3 old" src="https://github.com/user-attachments/assets/67722c64-529a-4486-9ac6-c8f0fc52c6fa" />

