### PR TITLE
[NL4, NL5, NL8] - Content Change - Edited Do you live with other people Page

### DIFF
--- a/runner/src/server/forms/close-contact-form-cca-mers.json
+++ b/runner/src/server/forms/close-contact-form-cca-mers.json
@@ -3690,12 +3690,16 @@
       "type": "string",
       "items": [
         {
-          "text": "people who live at the same address as you",
-          "value": "people who live at the same address as you"
+          "text": "usually live in the same address as you",
+          "value": "usually live in the same address as you"
         },
         {
-          "text": "people who have stayed overnight in the last 14 days",
-          "value": "people who have stayed overnight in the last 14 days"
+          "text": "people who have stayed overnight in the last 7 days",
+          "value": "people who have stayed overnight in the last 7 days"
+        },
+        {
+          "text": "you can provide contact details for, or receive communications on behalf of",
+          "value": "you can provide contact details for, or receive communications on behalf of"
         }
       ]
     },
@@ -3705,12 +3709,16 @@
       "type": "string",
       "items": [
         {
-          "text": "people who live at the same address as them",
-          "value": "people who live at the same address as them"
+          "text": "usually live in the same address as them",
+          "value": "usually live in the same address as them"
         },
         {
-          "text": "people who have stayed overnight in the last 14 days",
-          "value": "people who have stayed overnight in the last 14 days"
+          "text": "people who have stayed overnight in the last 7 days",
+          "value": "people who have stayed overnight in the last 7 days"
+        },
+        {
+          "text": "you can provide contact details for, or receive communications on behalf of",
+          "value": "you can provide contact details for, or receive communications on behalf of"
         }
       ]
     },

--- a/runner/src/server/forms/close-contact-form-cca-nl4.json
+++ b/runner/src/server/forms/close-contact-form-cca-nl4.json
@@ -393,10 +393,16 @@
       "title": "Do you live with other people?",
       "components": [
         {
+          "name": "doYouLiveWithOtherPeopleExplanation",
+          "options": {},
+          "type": "Para",
+          "content": "As you've tested positive for bird (avian) flu, it's important for us to know who you live with, so we can help them receive the right guidance, such as how to get tested and other health advice."
+        },
+        {
           "name": "AdEVNK",
           "options": {},
           "type": "Para",
-          "content": "This includes:"
+          "content": "This only includes people who:"
         },
         {
           "name": "kjpRbq",
@@ -423,7 +429,7 @@
           "options": {},
           "type": "Details",
           "title": "Why are we asking for this information?",
-          "content": "We ask this to identify people you live with who may be at risk. We may contact them to offer advice and guidance on how to keep themselves and others safe."
+          "content": "We ask this to identify people you live with and may have passed bird (avian) flu on to. This is so we can provide the right guidance to them or someone on their behalf, such as how to get tested and other health advice."
         }
       ],
       "next": [

--- a/runner/src/server/forms/close-contact-form-cca-nl4.json
+++ b/runner/src/server/forms/close-contact-form-cca-nl4.json
@@ -3696,12 +3696,16 @@
       "type": "string",
       "items": [
         {
-          "text": "people who live at the same address as you",
-          "value": "people who live at the same address as you"
+          "text": "usually live in the same address as you",
+          "value": "usually live in the same address as you"
         },
         {
-          "text": "people who have stayed overnight in the last 14 days",
-          "value": "people who have stayed overnight in the last 14 days"
+          "text": "people who have stayed overnight in the last 7 days",
+          "value": "people who have stayed overnight in the last 7 days"
+        },
+        {
+          "text": "you can provide contact details for, or receive communications on behalf of",
+          "value": "you can provide contact details for, or receive communications on behalf of"
         }
       ]
     },
@@ -3711,12 +3715,16 @@
       "type": "string",
       "items": [
         {
-          "text": "people who live at the same address as them",
-          "value": "people who live at the same address as them"
+          "text": "usually live in the same address as them",
+          "value": "usually live in the same address as them"
         },
         {
-          "text": "people who have stayed overnight in the last 14 days",
-          "value": "people who have stayed overnight in the last 14 days"
+          "text": "people who have stayed overnight in the last 7 days",
+          "value": "people who have stayed overnight in the last 7 days"
+        },
+        {
+          "text": "you can provide contact details for, or receive communications on behalf of",
+          "value": "you can provide contact details for, or receive communications on behalf of"
         }
       ]
     },

--- a/runner/src/server/forms/close-contact-form-cca-nl5.json
+++ b/runner/src/server/forms/close-contact-form-cca-nl5.json
@@ -393,10 +393,16 @@
       "title": "Do you live with other people?",
       "components": [
         {
+          "name": "doYouLiveWithOtherPeopleExplanation",
+          "options": {},
+          "type": "Para",
+          "content": "As you've tested positive for bird (avian) flu, it's important for us to know who you live with, so we can help them receive the right guidance, such as how to get tested and other health advice."
+        },
+        {
           "name": "AdEVNK",
           "options": {},
           "type": "Para",
-          "content": "This includes:"
+          "content": "This only includes people who:"
         },
         {
           "name": "kjpRbq",
@@ -423,7 +429,7 @@
           "options": {},
           "type": "Details",
           "title": "Why are we asking for this information?",
-          "content": "We ask this to identify people you live with and may have passed bird (avian) flu on to."
+          "content": "We ask this to identify people you live with and may have passed bird (avian) flu on to. This is so we can provide the right guidance to them or someone on their behalf, such as how to get tested and other health advice."
         }
       ],
       "next": [

--- a/runner/src/server/forms/close-contact-form-cca-nl5.json
+++ b/runner/src/server/forms/close-contact-form-cca-nl5.json
@@ -3696,12 +3696,16 @@
       "type": "string",
       "items": [
         {
-          "text": "people who live at the same address as you",
-          "value": "people who live at the same address as you"
+          "text": "usually live in the same address as you",
+          "value": "usually live in the same address as you"
         },
         {
-          "text": "people who have stayed overnight in the last 14 days",
-          "value": "people who have stayed overnight in the last 14 days"
+          "text": "people who have stayed overnight in the last 7 days",
+          "value": "people who have stayed overnight in the last 7 days"
+        },
+        {
+          "text": "you can provide contact details for, or receive communications on behalf of",
+          "value": "you can provide contact details for, or receive communications on behalf of"
         }
       ]
     },
@@ -3711,12 +3715,16 @@
       "type": "string",
       "items": [
         {
-          "text": "people who live at the same address as them",
-          "value": "people who live at the same address as them"
+          "text": "usually live in the same address as them",
+          "value": "usually live in the same address as them"
         },
         {
-          "text": "people who have stayed overnight in the last 14 days",
-          "value": "people who have stayed overnight in the last 14 days"
+          "text": "people who have stayed overnight in the last 7 days",
+          "value": "people who have stayed overnight in the last 7 days"
+        },
+        {
+          "text": "you can provide contact details for, or receive communications on behalf of",
+          "value": "you can provide contact details for, or receive communications on behalf of"
         }
       ]
     },

--- a/runner/src/server/forms/close-contact-form-cca-nl5.json
+++ b/runner/src/server/forms/close-contact-form-cca-nl5.json
@@ -423,7 +423,7 @@
           "options": {},
           "type": "Details",
           "title": "Why are we asking for this information?",
-          "content": "We ask this to identify people you live with who may be at risk. We may contact them to offer advice and guidance on how to keep themselves and others safe."
+          "content": "We ask this to identify people you live with and may have passed bird (avian) flu on to."
         }
       ],
       "next": [

--- a/runner/src/server/forms/close-contact-form-cca-nl5.json
+++ b/runner/src/server/forms/close-contact-form-cca-nl5.json
@@ -446,10 +446,16 @@
       "title": "Do they live with other people?",
       "components": [
         {
+          "name": "doYouLiveWithOtherPeopleExplanation",
+          "options": {},
+          "type": "Para",
+          "content": "As the person you are completing the form for has tested positive for bird (avian) flu, it's important for us to know who they live with, so we can help them receive the right guidance, such as how to get tested and other health advice."
+        },
+        {
           "name": "AdEVNK",
           "options": {},
           "type": "Para",
-          "content": "This includes:"
+          "content": "This only includes people who:"
         },
         {
           "name": "kjpRbq",
@@ -476,7 +482,7 @@
           "options": {},
           "type": "Details",
           "title": "Why are we asking for this information?",
-          "content": "We ask this to identify people the person you're completing this form for lives with who may be at risk. We may contact them to offer advice and guidance on how to keep themselves and others safe."
+          "content": "We ask this to identify people they live with and may have passed bird (avian) flu on to. This is so we can provide the right guidance to them or someone on their behalf, such as how to get tested and other health advice."
         }
       ],
       "next": [

--- a/runner/src/server/forms/close-contact-form-cca-nl8.json
+++ b/runner/src/server/forms/close-contact-form-cca-nl8.json
@@ -3696,16 +3696,12 @@
       "type": "string",
       "items": [
         {
-          "text": "usually live in the same address as you",
-          "value": "usually live in the same address as you"
+          "text": "people who live at the same address as you",
+          "value": "people who live at the same address as you"
         },
         {
-          "text": "people who have stayed overnight in the last 7 days",
-          "value": "people who have stayed overnight in the last 7 days"
-        },
-        {
-          "text": "you can provide contact details for, or receive communications on behalf of",
-          "value": "you can provide contact details for, or receive communications on behalf of"
+          "text": "people who have stayed overnight in the last 14 days",
+          "value": "people who have stayed overnight in the last 14 days"
         }
       ]
     },
@@ -3715,16 +3711,12 @@
       "type": "string",
       "items": [
         {
-          "text": "usually live in the same address as them",
-          "value": "usually live in the same address as them"
+          "text": "people who live at the same address as them",
+          "value": "people who live at the same address as them"
         },
         {
-          "text": "people who have stayed overnight in the last 7 days",
-          "value": "people who have stayed overnight in the last 7 days"
-        },
-        {
-          "text": "you can provide contact details for, or receive communications on behalf of",
-          "value": "you can provide contact details for, or receive communications on behalf of"
+          "text": "people who have stayed overnight in the last 14 days",
+          "value": "people who have stayed overnight in the last 14 days"
         }
       ]
     },

--- a/runner/src/server/forms/close-contact-form-cca-nl8.json
+++ b/runner/src/server/forms/close-contact-form-cca-nl8.json
@@ -3696,12 +3696,16 @@
       "type": "string",
       "items": [
         {
-          "text": "people who live at the same address as you",
-          "value": "people who live at the same address as you"
+          "text": "usually live in the same address as you",
+          "value": "usually live in the same address as you"
         },
         {
-          "text": "people who have stayed overnight in the last 14 days",
-          "value": "people who have stayed overnight in the last 14 days"
+          "text": "people who have stayed overnight in the last 7 days",
+          "value": "people who have stayed overnight in the last 7 days"
+        },
+        {
+          "text": "you can provide contact details for, or receive communications on behalf of",
+          "value": "you can provide contact details for, or receive communications on behalf of"
         }
       ]
     },
@@ -3711,12 +3715,16 @@
       "type": "string",
       "items": [
         {
-          "text": "people who live at the same address as them",
-          "value": "people who live at the same address as them"
+          "text": "usually live in the same address as them",
+          "value": "usually live in the same address as them"
         },
         {
-          "text": "people who have stayed overnight in the last 14 days",
-          "value": "people who have stayed overnight in the last 14 days"
+          "text": "people who have stayed overnight in the last 7 days",
+          "value": "people who have stayed overnight in the last 7 days"
+        },
+        {
+          "text": "you can provide contact details for, or receive communications on behalf of",
+          "value": "you can provide contact details for, or receive communications on behalf of"
         }
       ]
     },

--- a/runner/src/server/forms/close-contact-form-cca-nl8.json
+++ b/runner/src/server/forms/close-contact-form-cca-nl8.json
@@ -423,7 +423,7 @@
           "options": {},
           "type": "Details",
           "title": "Why are we asking for this information?",
-          "content": "We ask this to identify people you live with who may be at risk. We may contact them to offer advice and guidance on how to keep themselves and others safe."
+          "content": "We ask this to identify people you live with and may have passed bird (avian) flu on to."
         }
       ],
       "next": [

--- a/runner/src/server/forms/close-contact-form-cca-nl8.json
+++ b/runner/src/server/forms/close-contact-form-cca-nl8.json
@@ -393,10 +393,16 @@
       "title": "Do you live with other people?",
       "components": [
         {
+          "name": "doYouLiveWithOtherPeopleExplanation",
+          "options": {},
+          "type": "Para",
+          "content": "As you've tested postive for bird (avian) flue, it's important for us to know who you live with, so we can help them recieve the right guidance, such as how to get tested and other health advice."
+        },
+        {
           "name": "AdEVNK",
           "options": {},
           "type": "Para",
-          "content": "This includes:"
+          "content": "This only includes people who:"
         },
         {
           "name": "kjpRbq",
@@ -423,7 +429,7 @@
           "options": {},
           "type": "Details",
           "title": "Why are we asking for this information?",
-          "content": "We ask this to identify people you live with and may have passed bird (avian) flu on to."
+          "content": "We ask this to identify people you live with and may have passed bird (avian) flu on to. This is so we can provide the right guidance to them or someone on their behalf, such as how to get tested and other health advice."
         }
       ],
       "next": [

--- a/runner/src/server/forms/close-contact-form-cca-nl8.json
+++ b/runner/src/server/forms/close-contact-form-cca-nl8.json
@@ -396,7 +396,7 @@
           "name": "doYouLiveWithOtherPeopleExplanation",
           "options": {},
           "type": "Para",
-          "content": "As you've tested postive for bird (avian) flue, it's important for us to know who you live with, so we can help them recieve the right guidance, such as how to get tested and other health advice."
+          "content": "As you've tested positive for bird (avian) flu, it's important for us to know who you live with, so we can help them receive the right guidance, such as how to get tested and other health advice."
         },
         {
           "name": "AdEVNK",

--- a/runner/src/server/forms/close-contact-form-hpt-nl4.json
+++ b/runner/src/server/forms/close-contact-form-hpt-nl4.json
@@ -397,10 +397,16 @@
       "title": "Do you live with other people?",
       "components": [
         {
+          "name": "doYouLiveWithOtherPeopleExplanation",
+          "options": {},
+          "type": "Para",
+          "content": "As you've tested positive for bird (avian) flu, it's important for us to know who you live with, so we can help them receive the right guidance, such as how to get tested and other health advice."
+        },
+        {
           "name": "AdEVNK",
           "options": {},
           "type": "Para",
-          "content": "This includes:"
+          "content": "This only includes people who:"
         },
         {
           "name": "kjpRbq",
@@ -427,7 +433,7 @@
           "options": {},
           "type": "Details",
           "title": "Why are we asking for this information?",
-          "content": "We ask this to identify people you live with who may be at risk. We may contact them to offer advice and guidance on how to keep themselves and others safe."
+          "content": "We ask this to identify people you live with and may have passed bird (avian) flu on to. This is so we can provide the right guidance to them or someone on their behalf, such as how to get tested and other health advice."
         }
       ],
       "next": [

--- a/runner/src/server/forms/close-contact-form-hpt-nl4.json
+++ b/runner/src/server/forms/close-contact-form-hpt-nl4.json
@@ -450,10 +450,16 @@
       "title": "Do they live with other people?",
       "components": [
         {
+          "name": "doYouLiveWithOtherPeopleExplanation",
+          "options": {},
+          "type": "Para",
+          "content": "As the person you are completing the form for has tested positive for bird (avian) flu, it's important for us to know who they live with, so we can help them receive the right guidance, such as how to get tested and other health advice."
+        },
+        {
           "name": "AdEVNK",
           "options": {},
           "type": "Para",
-          "content": "This includes:"
+          "content": "This only includes people who:"
         },
         {
           "name": "kjpRbq",
@@ -480,7 +486,7 @@
           "options": {},
           "type": "Details",
           "title": "Why are we asking for this information?",
-          "content": "We ask this to identify people the person you're completing this form for lives with who may be at risk. We may contact them to offer advice and guidance on how to keep themselves and others safe."
+          "content": "We ask this to identify people they live with and may have passed bird (avian) flu on to. This is so we can provide the right guidance to them or someone on their behalf, such as how to get tested and other health advice."
         }
       ],
       "next": [
@@ -3697,12 +3703,16 @@
       "type": "string",
       "items": [
         {
-          "text": "people who live at the same address as you",
-          "value": "people who live at the same address as you"
+          "text": "usually live in the same address as you",
+          "value": "usually live in the same address as you"
         },
         {
-          "text": "people who have stayed overnight in the last 14 days",
-          "value": "people who have stayed overnight in the last 14 days"
+          "text": "people who have stayed overnight in the last 7 days",
+          "value": "people who have stayed overnight in the last 7 days"
+        },
+        {
+          "text": "you can provide contact details for, or receive communications on behalf of",
+          "value": "you can provide contact details for, or receive communications on behalf of"
         }
       ]
     },
@@ -3712,12 +3722,16 @@
       "type": "string",
       "items": [
         {
-          "text": "people who live at the same address as them",
-          "value": "people who live at the same address as them"
+          "text": "usually live in the same address as them",
+          "value": "usually live in the same address as them"
         },
         {
-          "text": "people who have stayed overnight in the last 14 days",
-          "value": "people who have stayed overnight in the last 14 days"
+          "text": "people who have stayed overnight in the last 7 days",
+          "value": "people who have stayed overnight in the last 7 days"
+        },
+        {
+          "text": "you can provide contact details for, or receive communications on behalf of",
+          "value": "you can provide contact details for, or receive communications on behalf of"
         }
       ]
     },

--- a/runner/src/server/forms/close-contact-form-hpt-nl5.json
+++ b/runner/src/server/forms/close-contact-form-hpt-nl5.json
@@ -427,7 +427,7 @@
           "options": {},
           "type": "Details",
           "title": "Why are we asking for this information?",
-          "content": "We ask this to identify people you live with who may be at risk. We may contact them to offer advice and guidance on how to keep themselves and others safe."
+          "content": "We ask this to identify people you live with and may have passed bird (avian) flu on to."
         }
       ],
       "next": [

--- a/runner/src/server/forms/close-contact-form-hpt-nl5.json
+++ b/runner/src/server/forms/close-contact-form-hpt-nl5.json
@@ -3697,12 +3697,16 @@
       "type": "string",
       "items": [
         {
-          "text": "people who live at the same address as you",
-          "value": "people who live at the same address as you"
+          "text": "usually live in the same address as you",
+          "value": "usually live in the same address as you"
         },
         {
-          "text": "people who have stayed overnight in the last 14 days",
-          "value": "people who have stayed overnight in the last 14 days"
+          "text": "people who have stayed overnight in the last 7 days",
+          "value": "people who have stayed overnight in the last 7 days"
+        },
+        {
+          "text": "you can provide contact details for, or receive communications on behalf of",
+          "value": "you can provide contact details for, or receive communications on behalf of"
         }
       ]
     },
@@ -3712,12 +3716,16 @@
       "type": "string",
       "items": [
         {
-          "text": "people who live at the same address as them",
-          "value": "people who live at the same address as them"
+          "text": "usually live in the same address as them",
+          "value": "usually live in the same address as them"
         },
         {
-          "text": "people who have stayed overnight in the last 14 days",
-          "value": "people who have stayed overnight in the last 14 days"
+          "text": "people who have stayed overnight in the last 7 days",
+          "value": "people who have stayed overnight in the last 7 days"
+        },
+        {
+          "text": "you can provide contact details for, or receive communications on behalf of",
+          "value": "you can provide contact details for, or receive communications on behalf of"
         }
       ]
     },

--- a/runner/src/server/forms/close-contact-form-hpt-nl5.json
+++ b/runner/src/server/forms/close-contact-form-hpt-nl5.json
@@ -450,10 +450,16 @@
       "title": "Do they live with other people?",
       "components": [
         {
+          "name": "doYouLiveWithOtherPeopleExplanation",
+          "options": {},
+          "type": "Para",
+          "content": "As the person you are completing the form for has tested positive for bird (avian) flu, it's important for us to know who they live with, so we can help them receive the right guidance, such as how to get tested and other health advice."
+        },
+        {
           "name": "AdEVNK",
           "options": {},
           "type": "Para",
-          "content": "This includes:"
+          "content": "This only includes people who:"
         },
         {
           "name": "kjpRbq",
@@ -480,7 +486,7 @@
           "options": {},
           "type": "Details",
           "title": "Why are we asking for this information?",
-          "content": "We ask this to identify people the person you're completing this form for lives with who may be at risk. We may contact them to offer advice and guidance on how to keep themselves and others safe."
+          "content": "We ask this to identify people they live with and may have passed bird (avian) flu on to. This is so we can provide the right guidance to them or someone on their behalf, such as how to get tested and other health advice."
         }
       ],
       "next": [

--- a/runner/src/server/forms/close-contact-form-hpt-nl5.json
+++ b/runner/src/server/forms/close-contact-form-hpt-nl5.json
@@ -397,10 +397,16 @@
       "title": "Do you live with other people?",
       "components": [
         {
+          "name": "doYouLiveWithOtherPeopleExplanation",
+          "options": {},
+          "type": "Para",
+          "content": "As you've tested positive for bird (avian) flu, it's important for us to know who you live with, so we can help them receive the right guidance, such as how to get tested and other health advice."
+        },
+        {
           "name": "AdEVNK",
           "options": {},
           "type": "Para",
-          "content": "This includes:"
+          "content": "This only includes people who:"
         },
         {
           "name": "kjpRbq",
@@ -427,7 +433,7 @@
           "options": {},
           "type": "Details",
           "title": "Why are we asking for this information?",
-          "content": "We ask this to identify people you live with and may have passed bird (avian) flu on to."
+          "content": "We ask this to identify people you live with and may have passed bird (avian) flu on to. This is so we can provide the right guidance to them or someone on their behalf, such as how to get tested and other health advice."
         }
       ],
       "next": [

--- a/runner/src/server/forms/close-contact-form-hpt-nl8.json
+++ b/runner/src/server/forms/close-contact-form-hpt-nl8.json
@@ -427,7 +427,7 @@
           "options": {},
           "type": "Details",
           "title": "Why are we asking for this information?",
-          "content": "We ask this to identify people you live with who may be at risk. We may contact them to offer advice and guidance on how to keep themselves and others safe."
+          "content": "We ask this to identify people you live with and may have passed bird (avian) flu on to."
         }
       ],
       "next": [

--- a/runner/src/server/forms/close-contact-form-hpt-nl8.json
+++ b/runner/src/server/forms/close-contact-form-hpt-nl8.json
@@ -397,10 +397,16 @@
       "title": "Do you live with other people?",
       "components": [
         {
+          "name": "doYouLiveWithOtherPeopleExplanation",
+          "options": {},
+          "type": "Para",
+          "content": "As you've tested postive for bird (avian) flue, it's important for us to know who you live with, so we can help them recieve the right guidance, such as how to get tested and other health advice."
+        },
+        {
           "name": "AdEVNK",
           "options": {},
           "type": "Para",
-          "content": "This includes:"
+          "content": "This only includes people who:"
         },
         {
           "name": "kjpRbq",
@@ -427,7 +433,7 @@
           "options": {},
           "type": "Details",
           "title": "Why are we asking for this information?",
-          "content": "We ask this to identify people you live with and may have passed bird (avian) flu on to."
+          "content": "We ask this to identify people you live with and may have passed bird (avian) flu on to. This is so we can provide the right guidance to them or someone on their behalf, such as how to get tested and other health advice."
         }
       ],
       "next": [

--- a/runner/src/server/forms/close-contact-form-hpt-nl8.json
+++ b/runner/src/server/forms/close-contact-form-hpt-nl8.json
@@ -3697,12 +3697,16 @@
       "type": "string",
       "items": [
         {
-          "text": "people who live at the same address as you",
-          "value": "people who live at the same address as you"
+          "text": "usually live in the same address as you",
+          "value": "usually live in the same address as you"
         },
         {
-          "text": "people who have stayed overnight in the last 14 days",
-          "value": "people who have stayed overnight in the last 14 days"
+          "text": "people who have stayed overnight in the last 7 days",
+          "value": "people who have stayed overnight in the last 7 days"
+        },
+        {
+          "text": "you can provide contact details for, or receive communications on behalf of",
+          "value": "you can provide contact details for, or receive communications on behalf of"
         }
       ]
     },
@@ -3712,12 +3716,16 @@
       "type": "string",
       "items": [
         {
-          "text": "people who live at the same address as them",
-          "value": "people who live at the same address as them"
+          "text": "usually live in the same address as them",
+          "value": "usually live in the same address as them"
         },
         {
-          "text": "people who have stayed overnight in the last 14 days",
-          "value": "people who have stayed overnight in the last 14 days"
+          "text": "people who have stayed overnight in the last 7 days",
+          "value": "people who have stayed overnight in the last 7 days"
+        },
+        {
+          "text": "you can provide contact details for, or receive communications on behalf of",
+          "value": "you can provide contact details for, or receive communications on behalf of"
         }
       ]
     },

--- a/runner/src/server/forms/close-contact-form-hpt-nl8.json
+++ b/runner/src/server/forms/close-contact-form-hpt-nl8.json
@@ -400,7 +400,7 @@
           "name": "doYouLiveWithOtherPeopleExplanation",
           "options": {},
           "type": "Para",
-          "content": "As you've tested postive for bird (avian) flue, it's important for us to know who you live with, so we can help them recieve the right guidance, such as how to get tested and other health advice."
+          "content": "As you've tested positive for bird (avian) flu, it's important for us to know who you live with, so we can help them receive the right guidance, such as how to get tested and other health advice."
         },
         {
           "name": "AdEVNK",

--- a/runner/src/server/forms/close-contact-form-mers.json
+++ b/runner/src/server/forms/close-contact-form-mers.json
@@ -3690,12 +3690,16 @@
       "type": "string",
       "items": [
         {
-          "text": "people who live at the same address as you",
-          "value": "people who live at the same address as you"
+          "text": "usually live in the same address as you",
+          "value": "usually live in the same address as you"
         },
         {
-          "text": "people who have stayed overnight in the last 14 days",
-          "value": "people who have stayed overnight in the last 14 days"
+          "text": "people who have stayed overnight in the last 7 days",
+          "value": "people who have stayed overnight in the last 7 days"
+        },
+        {
+          "text": "you can provide contact details for, or receive communications on behalf of",
+          "value": "you can provide contact details for, or receive communications on behalf of"
         }
       ]
     },
@@ -3705,12 +3709,16 @@
       "type": "string",
       "items": [
         {
-          "text": "people who live at the same address as them",
-          "value": "people who live at the same address as them"
+          "text": "usually live in the same address as them",
+          "value": "usually live in the same address as them"
         },
         {
-          "text": "people who have stayed overnight in the last 14 days",
-          "value": "people who have stayed overnight in the last 14 days"
+          "text": "people who have stayed overnight in the last 7 days",
+          "value": "people who have stayed overnight in the last 7 days"
+        },
+        {
+          "text": "you can provide contact details for, or receive communications on behalf of",
+          "value": "you can provide contact details for, or receive communications on behalf of"
         }
       ]
     },

--- a/runner/src/server/forms/close-contact-form-nl4.json
+++ b/runner/src/server/forms/close-contact-form-nl4.json
@@ -449,10 +449,16 @@
       "title": "Do they live with other people?",
       "components": [
         {
+          "name": "doYouLiveWithOtherPeopleExplanation",
+          "options": {},
+          "type": "Para",
+          "content": "As the person you are completing the form for has tested positive for bird (avian) flu, it's important for us to know who they live with, so we can help them receive the right guidance, such as how to get tested and other health advice."
+        },
+        {
           "name": "AdEVNK",
           "options": {},
           "type": "Para",
-          "content": "This includes:"
+          "content": "This only includes people who:"
         },
         {
           "name": "kjpRbq",
@@ -479,7 +485,7 @@
           "options": {},
           "type": "Details",
           "title": "Why are we asking for this information?",
-          "content": "We ask this to identify people the person you're completing this form for lives with who may be at risk. We may contact them to offer advice and guidance on how to keep themselves and others safe."
+          "content": "We ask this to identify people they live with and may have passed bird (avian) flu on to. This is so we can provide the right guidance to them or someone on their behalf, such as how to get tested and other health advice."
         }
       ],
       "next": [
@@ -3696,12 +3702,16 @@
       "type": "string",
       "items": [
         {
-          "text": "people who live at the same address as you",
-          "value": "people who live at the same address as you"
+          "text": "usually live in the same address as you",
+          "value": "usually live in the same address as you"
         },
         {
-          "text": "people who have stayed overnight in the last 14 days",
-          "value": "people who have stayed overnight in the last 14 days"
+          "text": "people who have stayed overnight in the last 7 days",
+          "value": "people who have stayed overnight in the last 7 days"
+        },
+        {
+          "text": "you can provide contact details for, or receive communications on behalf of",
+          "value": "you can provide contact details for, or receive communications on behalf of"
         }
       ]
     },
@@ -3711,12 +3721,16 @@
       "type": "string",
       "items": [
         {
-          "text": "people who live at the same address as them",
-          "value": "people who live at the same address as them"
+          "text": "usually live in the same address as them",
+          "value": "usually live in the same address as them"
         },
         {
-          "text": "people who have stayed overnight in the last 14 days",
-          "value": "people who have stayed overnight in the last 14 days"
+          "text": "people who have stayed overnight in the last 7 days",
+          "value": "people who have stayed overnight in the last 7 days"
+        },
+        {
+          "text": "you can provide contact details for, or receive communications on behalf of",
+          "value": "you can provide contact details for, or receive communications on behalf of"
         }
       ]
     },

--- a/runner/src/server/forms/close-contact-form-nl4.json
+++ b/runner/src/server/forms/close-contact-form-nl4.json
@@ -396,10 +396,16 @@
       "title": "Do you live with other people?",
       "components": [
         {
+          "name": "doYouLiveWithOtherPeopleExplanation",
+          "options": {},
+          "type": "Para",
+          "content": "As you've tested positive for bird (avian) flu, it's important for us to know who you live with, so we can help them receive the right guidance, such as how to get tested and other health advice."
+        },
+        {
           "name": "AdEVNK",
           "options": {},
           "type": "Para",
-          "content": "This includes:"
+          "content": "This only includes people who:"
         },
         {
           "name": "kjpRbq",
@@ -426,7 +432,7 @@
           "options": {},
           "type": "Details",
           "title": "Why are we asking for this information?",
-          "content": "We ask this to identify people you live with who may be at risk. We may contact them to offer advice and guidance on how to keep themselves and others safe."
+          "content": "We ask this to identify people you live with and may have passed bird (avian) flu on to. This is so we can provide the right guidance to them or someone on their behalf, such as how to get tested and other health advice."
         }
       ],
       "next": [

--- a/runner/src/server/forms/close-contact-form-nl5.json
+++ b/runner/src/server/forms/close-contact-form-nl5.json
@@ -449,10 +449,16 @@
       "title": "Do they live with other people?",
       "components": [
         {
+          "name": "doYouLiveWithOtherPeopleExplanation",
+          "options": {},
+          "type": "Para",
+          "content": "As the person you are completing the form for has tested positive for bird (avian) flu, it's important for us to know who they live with, so we can help them receive the right guidance, such as how to get tested and other health advice."
+        },
+        {
           "name": "AdEVNK",
           "options": {},
           "type": "Para",
-          "content": "This includes:"
+          "content": "This only includes people who:"
         },
         {
           "name": "kjpRbq",
@@ -479,7 +485,7 @@
           "options": {},
           "type": "Details",
           "title": "Why are we asking for this information?",
-          "content": "We ask this to identify people the person you're completing this form for lives with who may be at risk. We may contact them to offer advice and guidance on how to keep themselves and others safe."
+          "content": "We ask this to identify people they live with and may have passed bird (avian) flu on to. This is so we can provide the right guidance to them or someone on their behalf, such as how to get tested and other health advice."
         }
       ],
       "next": [
@@ -3715,12 +3721,16 @@
       "type": "string",
       "items": [
         {
-          "text": "people who live at the same address as them",
-          "value": "people who live at the same address as them"
+          "text": "usually live in the same address as them",
+          "value": "usually live in the same address as them"
         },
         {
-          "text": "people who have stayed overnight in the last 14 days",
-          "value": "people who have stayed overnight in the last 14 days"
+          "text": "people who have stayed overnight in the last 7 days",
+          "value": "people who have stayed overnight in the last 7 days"
+        },
+        {
+          "text": "you can provide contact details for, or receive communications on behalf of",
+          "value": "you can provide contact details for, or receive communications on behalf of"
         }
       ]
     },

--- a/runner/src/server/forms/close-contact-form-nl5.json
+++ b/runner/src/server/forms/close-contact-form-nl5.json
@@ -3696,12 +3696,16 @@
       "type": "string",
       "items": [
         {
-          "text": "people who live at the same address as you",
-          "value": "people who live at the same address as you"
+          "text": "usually live in the same address as you",
+          "value": "usually live in the same address as you"
         },
         {
-          "text": "people who have stayed overnight in the last 14 days",
-          "value": "people who have stayed overnight in the last 14 days"
+          "text": "people who have stayed overnight in the last 7 days",
+          "value": "people who have stayed overnight in the last 7 days"
+        },
+        {
+          "text": "you can provide contact details for, or receive communications on behalf of",
+          "value": "you can provide contact details for, or receive communications on behalf of"
         }
       ]
     },

--- a/runner/src/server/forms/close-contact-form-nl5.json
+++ b/runner/src/server/forms/close-contact-form-nl5.json
@@ -396,10 +396,16 @@
       "title": "Do you live with other people?",
       "components": [
         {
+          "name": "doYouLiveWithOtherPeopleExplanation",
+          "options": {},
+          "type": "Para",
+          "content": "As you've tested positive for bird (avian) flu, it's important for us to know who you live with, so we can help them receive the right guidance, such as how to get tested and other health advice."
+        },
+        {
           "name": "AdEVNK",
           "options": {},
           "type": "Para",
-          "content": "This includes:"
+          "content": "This only includes people who:"
         },
         {
           "name": "kjpRbq",
@@ -426,7 +432,7 @@
           "options": {},
           "type": "Details",
           "title": "Why are we asking for this information?",
-          "content": "We ask this to identify people you live with and may have passed bird (avian) flu on to."
+          "content": "We ask this to identify people you live with and may have passed bird (avian) flu on to. This is so we can provide the right guidance to them or someone on their behalf, such as how to get tested and other health advice."
         }
       ],
       "next": [

--- a/runner/src/server/forms/close-contact-form-nl5.json
+++ b/runner/src/server/forms/close-contact-form-nl5.json
@@ -426,7 +426,7 @@
           "options": {},
           "type": "Details",
           "title": "Why are we asking for this information?",
-          "content": "We ask this to identify people you live with who may be at risk. We may contact them to offer advice and guidance on how to keep themselves and others safe."
+          "content": "We ask this to identify people you live with and may have passed bird (avian) flu on to."
         }
       ],
       "next": [

--- a/runner/src/server/forms/close-contact-form-nl8.json
+++ b/runner/src/server/forms/close-contact-form-nl8.json
@@ -3644,12 +3644,16 @@
       "type": "string",
       "items": [
         {
-          "text": "people who live at the same address as you",
-          "value": "people who live at the same address as you"
+          "text": "usually live in the same address as you",
+          "value": "usually live in the same address as you"
         },
         {
-          "text": "people who have stayed overnight in the last 14 days",
-          "value": "people who have stayed overnight in the last 14 days"
+          "text": "people who have stayed overnight in the last 7 days",
+          "value": "people who have stayed overnight in the last 7 days"
+        },
+        {
+          "text": "you can provide contact details for, or receive communications on behalf of",
+          "value": "you can provide contact details for, or receive communications on behalf of"
         }
       ]
     },
@@ -3659,12 +3663,16 @@
       "type": "string",
       "items": [
         {
-          "text": "people who live at the same address as them",
-          "value": "people who live at the same address as them"
+          "text": "usually live in the same address as them",
+          "value": "usually live in the same address as them"
         },
         {
-          "text": "people who have stayed overnight in the last 14 days",
-          "value": "people who have stayed overnight in the last 14 days"
+          "text": "people who have stayed overnight in the last 7 days",
+          "value": "people who have stayed overnight in the last 7 days"
+        },
+        {
+          "text": "you can provide contact details for, or receive communications on behalf of",
+          "value": "you can provide contact details for, or receive communications on behalf of"
         }
       ]
     },

--- a/runner/src/server/forms/close-contact-form-nl8.json
+++ b/runner/src/server/forms/close-contact-form-nl8.json
@@ -396,10 +396,16 @@
       "title": "Do you live with other people?",
       "components": [
         {
+          "name": "doYouLiveWithOtherPeopleExplanation",
+          "options": {},
+          "type": "Para",
+          "content": "As you've tested postive for bird (avian) flue, it's important for us to know who you live with, so we can help them recieve the right guidance, such as how to get tested and other health advice."
+        },
+        {
           "name": "AdEVNK",
           "options": {},
           "type": "Para",
-          "content": "This includes:"
+          "content": "This only includes people who:"
         },
         {
           "name": "kjpRbq",
@@ -426,7 +432,7 @@
           "options": {},
           "type": "Details",
           "title": "Why are we asking for this information?",
-          "content": "We ask this to identify people you live with and may have passed bird (avian) flu on to."
+          "content": "We ask this to identify people you live with and may have passed bird (avian) flu on to. This is so we can provide the right guidance to them or someone on their behalf, such as how to get tested and other health advice."
         }
       ],
       "next": [

--- a/runner/src/server/forms/close-contact-form-nl8.json
+++ b/runner/src/server/forms/close-contact-form-nl8.json
@@ -397,10 +397,16 @@
       "title": "Do they live with other people?",
       "components": [
         {
+          "name": "doYouLiveWithOtherPeopleExplanation",
+          "options": {},
+          "type": "Para",
+          "content": "As the person you are completing the form for has tested positive for bird (avian) flu, it's important for us to know who they live with, so we can help them receive the right guidance, such as how to get tested and other health advice."
+        },
+        {
           "name": "AdEVNK",
           "options": {},
           "type": "Para",
-          "content": "This includes:"
+          "content": "This only includes people who:"
         },
         {
           "name": "kjpRbq",
@@ -427,7 +433,7 @@
           "options": {},
           "type": "Details",
           "title": "Why are we asking for this information?",
-          "content": "We ask this to identify people the person you're completing this form for lives with who may be at risk. We may contact them to offer advice and guidance on how to keep themselves and others safe."
+          "content": "We ask this to identify people they live with and may have passed bird (avian) flu on to. This is so we can provide the right guidance to them or someone on their behalf, such as how to get tested and other health advice."
         }
       ],
       "next": [

--- a/runner/src/server/forms/close-contact-form-nl8.json
+++ b/runner/src/server/forms/close-contact-form-nl8.json
@@ -399,7 +399,7 @@
           "name": "doYouLiveWithOtherPeopleExplanation",
           "options": {},
           "type": "Para",
-          "content": "As you've tested postive for bird (avian) flue, it's important for us to know who you live with, so we can help them recieve the right guidance, such as how to get tested and other health advice."
+          "content": "As you've tested positive for bird (avian) flu, it's important for us to know who you live with, so we can help them receive the right guidance, such as how to get tested and other health advice."
         },
         {
           "name": "AdEVNK",

--- a/runner/src/server/forms/close-contact-form-nl8.json
+++ b/runner/src/server/forms/close-contact-form-nl8.json
@@ -426,7 +426,7 @@
           "options": {},
           "type": "Details",
           "title": "Why are we asking for this information?",
-          "content": "We ask this to identify people you live with who may be at risk. We may contact them to offer advice and guidance on how to keep themselves and others safe."
+          "content": "We ask this to identify people you live with and may have passed bird (avian) flu on to."
         }
       ],
       "next": [


### PR DESCRIPTION
# Description

-> Updating description according to the following:L 
https://ukhsa.atlassian.net/browse/TECHCPP-8687

Please note that it is not included in the description to edit the for someone else form I have taken care of that as well

-> Change applied to Nl5 and NL8

<img width="811" height="519" alt="Screenshot 2026-05-13 at 09 40 49" src="https://github.com/user-attachments/assets/3d3f2120-0d70-41cd-8398-b54e5acb058a" />


## Context
TODO..

## Changes

- Change A
- Change B

## Type of change

What is the type of change you are making?

- [ ] Chore or documentation (non-breaking change that does not add functionality)
- [ ] ADR (Architectural Decision Record, non-breaking change that documents or proposes a decision)
- [ ] Refactor (non-breaking change that improves code quality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### PR title

PR titles should be prefixed with the type of change you are making, based on the [README.md#versioning](https://github.com/XGovFormBuilder/digital-form-builder?tab=readme-ov-file#versioning).
This is so that when performing a squash merge, the PR title is automatically used as the commit message.

Have you updated the PR title to match the type of change you are making?

- [ ] Yes
- [ ] No, I need help or guidance

# Testing

<!--
Several departments use XGovFormBuilder in production.
Automated tests help ensure that changes do not break existing functionality for another department.

Maintainers are sympathetic to the time constraints of government departments, but please try to be good citizens and add tests when possible.
-->

## Automated tests

Have you added automated tests?

- [ ] Yes, unit or integration tests
- [ ] Yes, end-to-end (cypress) tests
- [ ] No, tests are not required for this change
- [ ] No, I need help or guidance
- [ ] No (explain why tests are not required or can't be added at this time)

## Manual tests

Have you manually tested your changes?

- [ ] Yes
- [ ] No, manual tests are not required or sufficiently covered by automated tests

Have you attached an example form JSON or snippet for the reviewer in this PR?

- [ ] Yes
- [ ] No, any existing form can be used
- [ ] No, it is not required or not applicable

### Steps to test

<!--
Only fill out this section if you answered "Yes" to manually testing your changes.

In this section
- describe the tests that you ran to verify your changes
- provide instructions and a form JSON or snippet so we can reproduce the test if necessary

If uploading a form JSON, use the "attach files" feature in GitHub PR.
-->

1. Step 1
2. Step 2

# Documentation

Have you updated the documentation?

- [ ] Yes, I have updated [./docs](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs) for this change since additional explanation or steps to use/configure the feature is required
- [ ] Yes, I have added or updated an [ADR](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs/adr) for this change since it is large, complex, or has significant architectural implications
- [ ] Yes, I have added inline comments for hard-to-understand areas
- [ ] No, I am not sure if documentation is required
- [ ] No, documentation is not required for this change

# Discussion

> [!WARNING]
>
> Large or complex changes may require discussion with the maintainers before they can be merged. If it has not yet been discussed, it may delay the review process

Have you discussed this change with the maintainers?

- [ ] Yes, I have discussed this change with the maintainers on slack, email or via GitHub issues
- [ ] Yes, this change is an ADR to help kick-off discussion
- [ ] No, this change is small and does not require discussion
- [ ] No, I am not sure if one is required
