### PR TITLE
chore: ﻿Change KLS to use form level documentApiUploadUrl

### DIFF
--- a/runner/config/default.js
+++ b/runner/config/default.js
@@ -112,7 +112,7 @@ module.exports = {
   // If both the api env and node env are set to "production", the pay return url will need to be secure.
   // This is not the case if either are set to "test", or if the node env is set to "development"
   // payReturnUrl: "http://localhost:3009"
-  documentUploadApiUrl: "${KLSUploadAPILink}",
+  // documentUploadApiUrl: "", // Deprecated - use form level documentUploadApiUrl
   // ordnanceSurveyKey: "", // deprecated - this API is deprecated
   // browserRefreshUrl: "", // deprecated - idk what this does
 

--- a/runner/src/server/forms/kls-enquiries.json
+++ b/runner/src/server/forms/kls-enquiries.json
@@ -12,6 +12,7 @@
   },
   "webhookHmacSharedKey": "${KLSkey}",
   "fileUploadHmacSharedKey": "${KLSFileUploadKey}",
+  "documentUploadApiUrl": "${KLSUploadAPILink}",
   "magicLinkConfig": "kls-magic-link",
   "name": "UKHSA Knowledge and Library Services (KLS)",
   "pages": [

--- a/runner/src/server/plugins/engine/plugin.ts
+++ b/runner/src/server/plugins/engine/plugin.ts
@@ -13,7 +13,7 @@ import config from "../../config";
 import * as exit from "./pluginHandlers/exit";
 import {
   getFiles,
-  handleUpload,
+  secureHandleUpload,
   validateContentTypes,
 } from "./pluginHandlers/files/prehandlers";
 
@@ -329,7 +329,7 @@ export const plugin = {
         pre: [
           { method: getFiles, assign: "files" },
           { method: validateContentTypes, assign: "validFiles" },
-          { method: handleUpload },
+          { method: secureHandleUpload },
         ],
         handler: postHandler,
       },

--- a/runner/src/server/plugins/engine/pluginHandlers/files/prehandlers/__tests__/secureHandleUpload.jest.ts
+++ b/runner/src/server/plugins/engine/pluginHandlers/files/prehandlers/__tests__/secureHandleUpload.jest.ts
@@ -1,0 +1,61 @@
+import { secureHandleUpload } from "../secureHandleUpload";
+import { handleUpload } from "../handleUpload";
+import { HapiRequest, HapiResponseToolkit } from "src/server/types";
+
+jest.mock("../handleUpload");
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test("it supports unsecure file uploads", async () => {
+  const request = buildRequest("form-id");
+  const h = {} as HapiResponseToolkit;
+
+  await secureHandleUpload(request, h);
+
+  expect(handleUpload).toHaveBeenCalledWith(request, h, {
+    additionalHeaders: undefined,
+  });
+});
+
+test("it supports secure file uploads using fileUploadHmacSharedKey", async () => {
+  const request = buildRequest("my-form", "my-hmac-key");
+  const h = {} as HapiResponseToolkit;
+
+  await secureHandleUpload(request, h);
+
+  expect(handleUpload).toHaveBeenCalledWith(request, h, {
+    additionalHeaders: {
+      "X-Request-ID": expect.any(String),
+      "X-HMAC-Signature": expect.any(String),
+      "X-HMAC-Time": expect.any(String),
+    },
+  });
+});
+
+const buildRequest = (formId: string, fileUploadHmacSharedKey?: string) => {
+  const request = {
+    params: {
+      id: formId,
+    },
+    server: {
+      app: {
+        forms: {
+          [formId]: {},
+        },
+      },
+    },
+    yar: {
+      id: "session-id",
+    },
+  };
+
+  if (fileUploadHmacSharedKey) {
+    request["server"]["app"]["forms"][formId]["def"] = {
+      fileUploadHmacSharedKey: "my-hmac-key",
+    };
+  }
+
+  return (request as unknown) as HapiRequest;
+};

--- a/runner/src/server/plugins/engine/pluginHandlers/files/prehandlers/index.ts
+++ b/runner/src/server/plugins/engine/pluginHandlers/files/prehandlers/index.ts
@@ -1,3 +1,4 @@
 export { getFiles } from "./getFiles";
 export { validateContentTypes } from "./validateContentTypes";
 export { handleUpload } from "./handleUpload";
+export { secureHandleUpload } from "./secureHandleUpload";

--- a/runner/src/server/plugins/engine/pluginHandlers/files/prehandlers/secureHandleUpload.ts
+++ b/runner/src/server/plugins/engine/pluginHandlers/files/prehandlers/secureHandleUpload.ts
@@ -1,0 +1,49 @@
+import { HapiRequest, HapiResponseToolkit } from "server/types";
+import { createHmacRaw } from "server/utils/hmac";
+import { handleUpload } from "./handleUpload";
+import { FormModel } from "../../../models";
+
+export async function secureHandleUpload(
+  request: HapiRequest,
+  h: HapiResponseToolkit
+) {
+  let securityHeaders: Record<string, string> | undefined = undefined;
+
+  const formId = request.params?.id;
+  const forms = request.server?.app?.forms;
+
+  if (formId && forms) {
+    const formModel = forms[formId];
+
+    if (formModel) {
+      securityHeaders = await getSecurityHeaders(formModel, request);
+    }
+  }
+
+  return handleUpload(request, h, {
+    additionalHeaders: securityHeaders,
+  });
+}
+
+const getSecurityHeaders = async (
+  formModel: FormModel,
+  request: HapiRequest
+): Promise<Record<string, string> | undefined> => {
+  const hmacKey = formModel?.def?.fileUploadHmacSharedKey;
+  if (hmacKey) {
+    /* Used by KLS to support secure file uploads */
+    const sessionId = request.yar.id;
+    const [hmacSignature, requestTime] = await createHmacRaw(
+      sessionId,
+      hmacKey
+    );
+
+    return {
+      "X-Request-ID": sessionId,
+      "X-HMAC-Signature": hmacSignature.toString(),
+      "X-HMAC-Time": requestTime.toString(),
+    };
+  }
+
+  return undefined;
+};

--- a/runner/src/server/services/upload/uploadService.ts
+++ b/runner/src/server/services/upload/uploadService.ts
@@ -2,7 +2,6 @@ import FormData from "form-data";
 
 import config from "../../config";
 import { get, post, Response } from "../httpService";
-import { createHmacRaw } from "../../utils/hmac";
 import { HapiRequest, HapiResponseToolkit, HapiServer } from "../../types";
 import { ServerConfiguration } from "src/server/utils/configSchema";
 


### PR DESCRIPTION
Change KLS to use new form level documentApiUploadUrl functionality to remove it from being server level and allow for future forms to define their own upload urls

SecureHandleUpload plugin to wrap the existing HandleUpload plugin and provide security headers