### PR TITLE
generate reference in xgov

### DIFF
--- a/model/src/data-model/types.ts
+++ b/model/src/data-model/types.ts
@@ -132,6 +132,7 @@ export type ConfirmationPage = {
     title: string;
     paymentSkipped: Toggleable<string>;
     nextSteps: Toggleable<string>;
+    generatedReferenceContent: string;
     referenceTitle: string;
     referenceContent: string;
     hidePanel?: boolean;
@@ -313,4 +314,5 @@ export type FormDefinition = {
   addressLookupConfig?: AddressLookupConfig;
   error500ContactEmail?: string | undefined;
   summaryConfig?: SummaryConfig;
+  generateReference?: boolean | undefined;
 };

--- a/model/src/schema/schema.ts
+++ b/model/src/schema/schema.ts
@@ -157,6 +157,7 @@ const confirmationPageSchema = joi.object({
       nextSteps: toggleableString.default(
         "You will receive an email with details with the next steps."
       ),
+      generatedReferenceContent: joi.string().optional(),
       referenceTitle: joi.string(),
       referenceContent: joi.string(),
       hidePanel: joi.boolean().optional(),
@@ -456,6 +457,7 @@ export const Schema = joi
     addressLookupConfig: addressLookupConfigSchema.optional(),
     error500ContactEmail: joi.string().optional(),
     summaryConfig: summaryConfigSchema.optional(),
+    generateReference: joi.boolean().optional(),
   });
 
 /**

--- a/runner/src/server/forms/order-a-radon-risk-report.json
+++ b/runner/src/server/forms/order-a-radon-risk-report.json
@@ -789,6 +789,39 @@
       "next": []
     }
   ],
+  "specialPages": {
+    "confirmationPage": {
+      "customText": {
+        "title": "Risk report ready",
+        "nextSteps": false,
+        "generatedReferenceContent": "Your order number is",
+        "hidePanel": false
+      },
+      "components": [
+        {
+          "name": "introEmail",
+          "type": "Para",
+          "options": {
+            "condition": "isEmailDelivery"
+          },
+          "content": "<p class=\"govuk-body-m\">Your radon risk report has been sent to {{ emailAddress }}</p>"
+        },
+        {
+          "name": "introEmail",
+          "type": "Para",
+          "options": {
+            "condition": "isPostDelivery"
+          },
+          "content": "<p class=\"govuk-body-m\">Your radon risk report will be sent to {{ deliveryAddress_matchedAddress.address }} within 3 to 6 working days.</p>"
+        },
+        {
+          "name": "final links",
+          "type": "Para",
+          "content": "<p class=\"govuk-body-m\"><a href=\"https://www.gov.uk/health-protection-team\" target=”_blank”>What did you think of this service?</a> (takes 30 seconds)</p></br><p class=\"govuk-body-m\"><a href=\"https://www.gov.uk/health-protection-team\" target=”_blank”>Go to Radon services for homeowners or householders</a></p>"
+        }
+      ]
+    }
+  },
   "lists": [
     {
       "title": "How would you like to receive your report?",
@@ -1032,6 +1065,7 @@
       }
     ]
   },
+  "generateReference": true,
   "fees": [],
   "outputs": [
     {

--- a/runner/src/server/forms/radon-enquiry.json
+++ b/runner/src/server/forms/radon-enquiry.json
@@ -497,7 +497,7 @@
         },
         {
           "text": "Taurus and IMBA Internal Dosimetry Software",
-          "value": "Taurus and IMBA Internal Dosimetry Softwar",
+          "value": "Taurus and IMBA Internal Dosimetry Software",
           "description": "Software for calculating internal radiation doses from intakes of radionuclides"
         },
         {

--- a/runner/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/runner/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -414,6 +414,21 @@ export class SummaryViewModel {
     });
   }
 
+  addReferenceToWebhook(reference: string) {
+    this._webhookData?.questions?.push({
+      category: null,
+      question: "Reference",
+      fields: [
+        {
+          key: "reference",
+          title: "Reference",
+          type: "string",
+          answer: reference,
+        },
+      ],
+    });
+  }
+
   private addFeedbackSourceDataToWebhook(
     webhookData,
     model: FormModel,

--- a/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -10,6 +10,7 @@ import {
 import config from "server/config";
 import { FeesModel } from "server/plugins/engine/models/submission";
 import { isMultipleApiKey } from "@xgovformbuilder/model";
+import { nanoid } from "nanoid";
 
 export class SummaryPageController extends PageController {
   /**
@@ -171,6 +172,14 @@ export class SummaryPageController extends PageController {
         }
 
         summaryViewModel.addDeclarationAsQuestion();
+      }
+
+      if (model.def?.generateReference == true) {
+        const reference = nanoid();
+        summaryViewModel.addReferenceToWebhook(reference);
+        await cacheService.mergeState(request, {
+          generatedReference: reference,
+        });
       }
 
       await cacheService.mergeState(request, {

--- a/runner/src/server/plugins/initialiseSession/types.ts
+++ b/runner/src/server/plugins/initialiseSession/types.ts
@@ -17,6 +17,7 @@ export type InitialiseSessionOptions = {
     title: string;
     paymentSkipped?: false | string;
     nextSteps?: false | string;
+    generatedReferenceContent?: string;
     hidePanel?: boolean;
   };
   components: ContentComponentsDef[];

--- a/runner/src/server/schemas/webhookSchema.ts
+++ b/runner/src/server/schemas/webhookSchema.ts
@@ -78,6 +78,7 @@ const optionsSchema: joi.ObjectSchema<
       title: joi.string().optional().allow(false, ""),
       paymentSkipped: joi.string().optional().allow(false, ""),
       nextSteps: joi.string().optional().allow(false, ""),
+      generatedReferenceContent: joi.string().optional().allow(false, ""),
       hidePanel: joi.boolean().optional(),
     })
     .optional(),

--- a/runner/src/server/services/statusService.ts
+++ b/runner/src/server/services/statusService.ts
@@ -354,7 +354,7 @@ export class StatusService {
     formModel: FormModel,
     newReference?: string
   ) {
-    const { reference, pay, callback } = state;
+    const { reference, pay, callback, generatedReference = null } = state;
     this.logger.info(
       ["StatusService", "getViewModel"],
       `generating viewModel for ${newReference ?? reference}`
@@ -366,6 +366,7 @@ export class StatusService {
     let model = {
       reference: referenceToDisplay,
       ...(pay && { paymentSkipped: pay.paymentSkipped }),
+      ...(generatedReference && { generatedReference }),
     };
 
     const confirmationPageDef = formModel.def.specialPages?.confirmationPage;

--- a/runner/src/server/views/confirmation.html
+++ b/runner/src/server/views/confirmation.html
@@ -16,7 +16,13 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% set tmpl = 'Your reference number<br><strong>' + reference + '</strong>' if reference else '' %}
+      {% if customText.generatedReferenceContent %}
+        {% set tmpl = customText.generatedReferenceContent + '<br><strong>' + generatedReference + '</strong>' %}
+      {% elif reference %}
+        {% set tmpl = 'Your reference number<br><strong>' + reference + '</strong>' %}
+      {% else %}
+        {% set tmpl = '' %}
+      {% endif %}
         {% if reference %}
           <p class="govuk-body">Your reference number is: <strong>{{ reference }}</strong></p>
         {% endif %}


### PR DESCRIPTION
RPS-1378, RPS-1379, RPS-1468

Add ability for XGOV to create a reference using nanoid, which is already used in the payment service, with generateReference form variable

Use generatedReferenceContent to display your generated reference in the end panel with custom text

Fix typo in radon-enquiry