### PR TITLE
Radon enquiry output to AWS

### DIFF
--- a/model/src/data-model/types.ts
+++ b/model/src/data-model/types.ts
@@ -113,7 +113,7 @@ export type WebhookOutputConfiguration = {
   url: string;
   sendAdditionalPayMetadata?: boolean;
   allowRetry?: boolean;
-  payload?: Record<string, unknown>;
+  payload?: Record<string, string>;
 };
 
 export type OutputConfiguration =

--- a/model/src/data-model/types.ts
+++ b/model/src/data-model/types.ts
@@ -113,6 +113,7 @@ export type WebhookOutputConfiguration = {
   url: string;
   sendAdditionalPayMetadata?: boolean;
   allowRetry?: boolean;
+  payload?: Record<string, unknown>;
 };
 
 export type OutputConfiguration =

--- a/model/src/schema/schema.ts
+++ b/model/src/schema/schema.ts
@@ -266,6 +266,7 @@ const webhookSchema = joi.object().keys({
   url: joi.string(),
   sendAdditionalPayMetadata: joi.boolean().optional().default(false),
   allowRetry: joi.boolean().default(true),
+  payload: joi.object().unknown(true).optional(),
 });
 
 const outputSchema = joi.object().keys({

--- a/runner/src/server/forms/order-a-radon-risk-report.json
+++ b/runner/src/server/forms/order-a-radon-risk-report.json
@@ -828,9 +828,12 @@
       "name": "deliveryMethodList",
       "type": "string",
       "items": [
-        { "text": "Email (£3.90) - delivered instantly", "value": "Email" },
         {
-          "text": "Post (£5.24) - delivered within 3 to 6 working days",
+          "text": "Digital report (£3.90) - delivered instantly",
+          "value": "Email"
+        },
+        {
+          "text": "Printed report (£5.24) - delivered within 3 to 6 working days",
           "value": "Post"
         }
       ]

--- a/runner/src/server/forms/radon-enquiry.json
+++ b/runner/src/server/forms/radon-enquiry.json
@@ -164,7 +164,7 @@
       "title": "Your enquiry details",
       "components": [
         {
-          "name": "firstname",
+          "name": "firstName",
           "options": {
             "customValidationMessages": {
               "any.required": "Enter your first name",
@@ -178,7 +178,7 @@
           "title": "Your first name"
         },
         {
-          "name": "lastname",
+          "name": "lastName",
           "options": {
             "customValidationMessages": {
               "any.required": "Enter your last name",
@@ -278,7 +278,7 @@
           "options": {
             "condition": "ojQCvt"
           },
-          "content": "<table class=\"govuk-table\"><caption class=\"govuk-table__caption govuk-table__caption--m\">Your enquiry details</caption><tbody class=\"govuk-table__body\"><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">First name</th><td class=\"govuk-table__cell\">{{ firstname }}</td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Last Name</th><td class=\"govuk-table__cell\">{{ lastname }}</td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Organisation</th><td class=\"govuk-table__cell\">{{ organisation }}</td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Email</th><td class=\"govuk-table__cell\">{{ email }}</td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Category</th><td class=\"govuk-table__cell\">{{ supportType }}</td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Service</th><td class=\"govuk-table__cell\">{{ service }}</td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Request information</th><td class=\"govuk-table__cell\">{{ requestInformation }}</td></tr></tbody></table>"
+          "content": "<table class=\"govuk-table\"><caption class=\"govuk-table__caption govuk-table__caption--m\">Your enquiry details</caption><tbody class=\"govuk-table__body\"><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">First name</th><td class=\"govuk-table__cell\">{{ firstName }}</td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Last Name</th><td class=\"govuk-table__cell\">{{ lastName }}</td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Organisation</th><td class=\"govuk-table__cell\">{{ organisation }}</td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Email</th><td class=\"govuk-table__cell\">{{ email }}</td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Category</th><td class=\"govuk-table__cell\">{{ supportType }}</td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Service</th><td class=\"govuk-table__cell\">{{ service }}</td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Request information</th><td class=\"govuk-table__cell\">{{ requestInformation }}</td></tr></tbody></table>"
         },
         {
           "name": "tableNoService",
@@ -286,7 +286,7 @@
           "options": {
             "condition": "tvCQjo"
           },
-          "content": "<table class=\"govuk-table\"><caption class=\"govuk-table__caption govuk-table__caption--m\">Your enquiry details</caption><tbody class=\"govuk-table__body\"><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">First name</th><td class=\"govuk-table__cell\">{{ firstname }}</td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Last Name</th><td class=\"govuk-table__cell\">{{ lastname }}</td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Organisation</th><td class=\"govuk-table__cell\">{{ organisation }}</td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Email</th><td class=\"govuk-table__cell\">{{ email }}</td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Category</th><td class=\"govuk-table__cell\">{{ supportType }}</td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Request information</th><td class=\"govuk-table__cell\">{{ requestInformation }}</td></tr></tbody></table>"
+          "content": "<table class=\"govuk-table\"><caption class=\"govuk-table__caption govuk-table__caption--m\">Your enquiry details</caption><tbody class=\"govuk-table__body\"><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">First name</th><td class=\"govuk-table__cell\">{{ firstName }}</td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Last Name</th><td class=\"govuk-table__cell\">{{ lastName }}</td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Organisation</th><td class=\"govuk-table__cell\">{{ organisation }}</td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Email</th><td class=\"govuk-table__cell\">{{ email }}</td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Category</th><td class=\"govuk-table__cell\">{{ supportType }}</td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Request information</th><td class=\"govuk-table__cell\">{{ requestInformation }}</td></tr></tbody></table>"
         },
         {
           "name": "final links",
@@ -753,14 +753,31 @@
     }
   ],
   "fees": [],
+  "secureFormSubmissionConfig": {
+    "tenantId": "${RPS_TENANT_ID}",
+    "clientId": "${RPS_CLIENT_ID}",
+    "clientSecret": "${RPS_CLIENT_SECRET}",
+    "scopes": ["${RPS_SCOPES}"],
+    "useAwsWafUserAgentWorkaround": true
+  },
   "outputs": [
     {
       "name": "AgHhXn",
       "title": "webhookOutput",
       "type": "webhook",
       "outputConfiguration": {
-        "url": "https://webho.ok",
-        "allowRetry": true
+        "url": "${RPS_RADON_ENQUIRY_URL}",
+        "allowRetry": true,
+        "payload": {
+          "uuid": "generatedReference",
+          "firstName": "firstName",
+          "lastName": "lastName",
+          "email": "email",
+          "organisation": "organisation",
+          "subject": "supportType",
+          "description": "requestInformation",
+          "service": "RPS"
+        }
       }
     }
   ],
@@ -768,6 +785,7 @@
     "feedbackForm": false,
     "url": ""
   },
+  "generateReference": true,
   "version": 2,
   "skipSummary": true,
   "feeOptions": {}

--- a/runner/src/server/plugins/engine/models/submission/Outputs.ts
+++ b/runner/src/server/plugins/engine/models/submission/Outputs.ts
@@ -52,6 +52,7 @@ export class Outputs {
               sendAdditionalPayMetadata:
                 webhookOutputConfiguration.sendAdditionalPayMetadata,
               allowRetry: webhookOutputConfiguration.allowRetry,
+              payload: webhookOutputConfiguration.payload,
             },
           };
         default:

--- a/runner/src/server/plugins/engine/models/submission/types.ts
+++ b/runner/src/server/plugins/engine/models/submission/types.ts
@@ -37,7 +37,7 @@ type WebhookOutputData = {
     url: string;
     sendAdditionalPayMetadata?: boolean;
     allowRetry?: boolean;
-    customPayloadFields?: Record<string, string>;
+    payload?: Record<string, string>;
   };
 };
 

--- a/runner/src/server/plugins/engine/models/submission/types.ts
+++ b/runner/src/server/plugins/engine/models/submission/types.ts
@@ -37,6 +37,7 @@ type WebhookOutputData = {
     url: string;
     sendAdditionalPayMetadata?: boolean;
     allowRetry?: boolean;
+    customPayloadFields?: Record<string, string>;
   };
 };
 

--- a/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -10,7 +10,7 @@ import {
 import config from "server/config";
 import { FeesModel } from "server/plugins/engine/models/submission";
 import { isMultipleApiKey } from "@xgovformbuilder/model";
-import { nanoid } from "nanoid";
+import { v4 as uuidv4 } from "uuid";
 
 export class SummaryPageController extends PageController {
   /**
@@ -175,7 +175,7 @@ export class SummaryPageController extends PageController {
       }
 
       if (model.def?.generateReference == true) {
-        const reference = nanoid();
+        const reference = uuidv4();
         summaryViewModel.addReferenceToWebhook(reference);
         await cacheService.mergeState(request, {
           generatedReference: reference,

--- a/runner/src/server/services/statusService.ts
+++ b/runner/src/server/services/statusService.ts
@@ -185,9 +185,14 @@ export class StatusService {
     const firstWebhook = outputs?.find((output) => output.type === "webhook");
     const otherOutputs = outputs?.filter((output) => output !== firstWebhook);
     if (firstWebhook) {
+      const payload = this.resolvePayload(
+        firstWebhook.outputData.payload,
+        formData,
+        state
+      );
       newReference = await this.webhookService.postRequest(
         firstWebhook.outputData.url,
-        { ...formData },
+        { ...formData, ...payload },
         "POST",
         firstWebhook.outputData.sendAdditionalPayMetadata,
         customSecurityHeaders
@@ -227,6 +232,14 @@ export class StatusService {
     };
   }
 
+  resolvePayload(payload: Record<string, string>, formData, state) {
+    return Object.fromEntries(
+      Object.entries(payload).map(([key, value]) => {
+        const resolved = formData[value] ?? state[value] ?? value;
+        return [key, resolved];
+      })
+    );
+  }
   /**
    * Appends `{paymentSkipped: true}` to the `metadata` property and drops the `fees` property if the user has chosen to skip payment
    */

--- a/runner/src/server/services/statusService.ts
+++ b/runner/src/server/services/statusService.ts
@@ -232,6 +232,16 @@ export class StatusService {
     };
   }
 
+  /**
+   * Injects values from `formData` and `state` into the payload structure
+   * If a value is not found in `formData` or `state`, it defaults to the value
+   * in the payload structure
+   *
+   * @param payload
+   * @param formData
+   * @param state
+   * @returns
+   */
   resolvePayload(payload: Record<string, string>, formData, state) {
     return Object.fromEntries(
       Object.entries(payload).map(([key, value]) => {


### PR DESCRIPTION
RPS-1461, RPS-1468

Added radon enquiry secure form config and webhook url

Added ability to send a custom payload of key value pairs which draws values from the form data, the state, or just the value input into the config.

Changed name fields to match expected names on AWS

Changed nanoid reference to uuid

Change email and post in risk report to Digital report and Printed report