### PR TITLE
RPS-1172: Fixed navigation issues when changing values on summary page

### DIFF
--- a/model/src/schema/schema.ts
+++ b/model/src/schema/schema.ts
@@ -128,6 +128,7 @@ const pageSchema = joi.object().keys({
   backLinkFallback: joi.string().optional(),
   disableBackLink: joi.bool().optional(),
   customButtonText: joi.string().optional(),
+  hideContinueButton: joi.boolean().optional(),
 });
 
 const startNavigationLinkSchema = joi.object().keys({

--- a/runner/src/server/forms/order-a-radon-risk-report.json
+++ b/runner/src/server/forms/order-a-radon-risk-report.json
@@ -29,12 +29,12 @@
           "content": "<p class=\"govuk-body-m\">The report does not tell you the radon level inside the property. To find this out, you need to do a 3‑month test using a <a href=\"/order-a-radon-home-test-kit\">radon gas test pack</a>.</p><p class=\"govuk-body-m\">Basements and cellar rooms are at a higher risk of radon. If a room you use frequently is below ground level, such as a kitchen or office, you should do a radon test, even if the property is not in a radon Affected Area.</p><p class=\"govuk-body-m\">Each report costs £3.90 and will be sent to an email address you provide. Alternatively, you can request a physical report to be sent by post for an additional fee.</p><p class=\"govuk-body-m\"><a href=\"https://www.ukradon.org/cms/assets/gfx/content/resource_5095cs45be58330c.pdf\">Read a sample report</a></p><h3 class=\"govuk-heading-m\">Before you start</h3><p class=\"govuk-body-m\">This service is for buildings up to 25 metres in any direction.</p><p class=\"govuk-body-m\">This report is not suitable for larger buildings. In this case, contact the <a href=\"http://shop.bgs.ac.uk/georeports\">British Geological Survey (BGS)</a>.</p><p class=\"govuk-body-m\">You'll need:</p><p class=\"govuk-body-m\"><ul class=\"govuk-list govuk-list--bullet\"><li>a valid UK address for the risk report</li><li>a valid email address or a UK postal delivery address</li><li>your payment details</li></ul></p>"
         }
       ],
-      "next": [{ "path": "/order-risk-report-find-an-address" }],
+      "next": [{ "path": "/order-risk-report-find-a-report-address" }],
       "controller": "./pages/start.js"
     },
 
     {
-      "path": "/order-risk-report-find-an-address",
+      "path": "/order-risk-report-find-a-report-address",
       "title": "What address are you ordering a risk report for?",
       "components": [
         {
@@ -94,24 +94,24 @@
           "name": "enterManuallyLink",
           "options": {},
           "type": "Html",
-          "content": "<br><a href=\"enter-address-manually\">Enter address manually</a>"
+          "content": "<br><a href=\"order-risk-report-enter-report-address-manually{% if returnUrl %}?returnUrl={{ returnUrl | urlencode }}{% endif %}\">Enter address manually</a>"
         }
       ],
       "controller": "FindAnAddressPageController",
       "next": [
         {
-          "path": "/is-this-the-correct-address",
+          "path": "/order-risk-report-is-this-the-correct-report-address",
           "condition": "hasMatchedReportAddressCondition"
         },
-        { "path": "/select-an-address" },
+        { "path": "/order-risk-report-select-a-report-address" },
         {
-          "path": "/no-addresses-found",
+          "path": "/order-risk-report-no-report-addresses-found",
           "condition": "noReportAddressesCondition"
         }
       ]
     },
     {
-      "path": "/is-this-the-correct-address",
+      "path": "/order-risk-report-is-this-the-correct-report-address",
       "title": "Is this the correct address?",
       "components": [
         {
@@ -148,14 +148,14 @@
       ],
       "controller": "SelectAnAddressPageController",
       "options": {
-        "changePath": "/order-risk-report-find-an-address"
+        "changePath": "/order-risk-report-find-a-report-address"
       },
       "componentsAfter": [
         {
           "name": "enterManuallyLink",
           "options": {},
           "type": "Html",
-          "content": "<br><a href=\"enter-address-manually\">Enter address manually</a>"
+          "content": "<br><a href=\"order-risk-report-enter-report-address-manually{% if returnUrl %}?returnUrl={{ returnUrl | urlencode }}{% endif %}\">Enter address manually</a>"
         }
       ],
       "next": [
@@ -163,11 +163,15 @@
           "path": "/how-would-you-like-to-receive-your-report",
           "condition": "isCorrectReportAddress"
         },
-        { "path": "/select-an-address" }
+        {
+          "path": "/order-risk-report-no-report-addresses-found",
+          "condition": "reportAddressOnlyOneAddressCondition"
+        },
+        { "path": "/order-risk-report-select-a-report-address" }
       ]
     },
     {
-      "path": "/select-an-address",
+      "path": "/order-risk-report-select-a-report-address",
       "title": "Select an address",
       "components": [
         {
@@ -180,7 +184,7 @@
           "name": "searchAgain",
           "options": {},
           "type": "Html",
-          "content": "<p class=\"govuk-body-m\"><a href=\"order-risk-report-find-an-address\">Change your search</a> if the address you're looking for is not listed.</p>"
+          "content": "<p class=\"govuk-body-m\"><a href=\"order-risk-report-find-a-report-address{% if returnUrl %}?returnUrl={{ returnUrl | urlencode }}{% endif %}\">Change your search</a> if the address you're looking for is not listed.</p>"
         },
         {
           "name": "addressType",
@@ -205,41 +209,60 @@
       ],
       "controller": "SelectAnAddressPageController",
       "options": {
-        "changePath": "/order-risk-report-find-an-address"
+        "changePath": "/order-risk-report-find-a-report-address"
       },
-      "next": [{ "path": "/how-would-you-like-to-receive-your-report" }],
+      "next": [
+        { "path": "/order-risk-report-is-this-the-correct-report-address" }
+      ],
       "componentsAfter": [
         {
           "name": "enterManuallyLink",
           "options": {},
           "type": "Html",
-          "content": "<br><a href=\"enter-address-manually\">Enter address manually</a>"
+          "content": "<br><a href=\"order-risk-report-enter-report-address-manually{% if returnUrl %}?returnUrl={{ returnUrl | urlencode }}{% endif %}\">Enter address manually</a>"
         }
       ]
     },
     {
-      "path": "/no-addresses-found",
-      "title": "No addresses found for {{ reportAddress_postcodeLookup }} and {{ reportAddress_buildingLookup }}",
+      "path": "/order-risk-report-no-report-addresses-found",
+      "title": "No addresses found for ‘{{ reportAddress_postcodeLookup }}’ and ‘{{ reportAddress_buildingLookup }}’",
+      "options": {
+        "hideContinueButton": true
+      },
       "components": [
         {
           "name": "noAddressesFoundMessage",
           "options": {},
           "type": "Para",
-          "content": "Check your address for mistakes, then try again.<br><br>Check you have entered the address correctly, then try again."
+          "content": "Check your postcode and building number or name for mistakes, then try again.<br><br>Check you have entered the postcode and building number or name correctly, then try again."
         },
         {
           "name": "searchAgain",
           "options": {},
           "type": "Html",
-          "content": "<p class=\"govuk-body-m\"><a href=\"order-risk-report-find-an-address\">Change your search</a> or <a href=\"enter-address-manually\">enter address manually</a></p>"
+          "content": "<p class=\"govuk-body-m\"><a href=\"order-risk-report-find-a-report-address{% if returnUrl %}?returnUrl={{ returnUrl | urlencode }}{% endif %}\">Change your search</a> or <a href=\"order-risk-report-enter-report-address-manually{% if returnUrl %}?returnUrl={{ returnUrl | urlencode }}{% endif %}\">enter address manually</a></p>"
         }
       ],
-      "next": [{ "path": "/order-risk-report-find-an-address" }]
+      "next": [
+        { "path": "/order-risk-report-find-a-report-address" },
+        {
+          "path": "/order-risk-report-enter-report-address-manually",
+          "condition": "reportAddressEnteredManuallyCondition"
+        }
+      ]
     },
     {
-      "path": "/enter-address-manually",
+      "path": "/order-risk-report-enter-report-address-manually",
       "title": "What is the address you want a risk report for?",
       "components": [
+        {
+          "name": "addressType",
+          "options": {
+            "exposeToContext": true,
+            "value": "reportAddress"
+          },
+          "type": "HiddenField"
+        },
         {
           "name": "reportAddress_addressLine1Lookup",
           "options": {
@@ -306,34 +329,37 @@
       "controller": "FindAnAddressPageController",
       "next": [
         {
-          "path": "/is-this-the-correct-address",
+          "path": "/order-risk-report-is-this-the-correct-report-address",
           "condition": "hasMatchedReportAddressCondition"
         },
-        { "path": "/select-an-address" },
+        { "path": "/order-risk-report-select-a-report-address" },
         {
-          "path": "/cannot-find-address",
+          "path": "/order-risk-report-cannot-find-report-address",
           "condition": "noReportAddressesCondition"
         }
       ]
     },
     {
-      "path": "/cannot-find-address",
+      "path": "/order-risk-report-cannot-find-report-address",
       "title": "We cannot find your address",
+      "options": {
+        "hideContinueButton": true
+      },
       "components": [
         {
           "name": "noAddressesFoundMessage",
           "options": {},
           "type": "Para",
-          "content": "No addresses found for {{ addressLine1Lookup }}, {{ postcodeLookup }}<br><br>Check your address for mistakes, then try again.<br><br>Check you have entered the address correctly, then try again."
+          "content": "No address found for {{ reportAddress_addressLine1Lookup }}{% if reportAddress_addressLine2Lookup %}, {{ reportAddress_addressLine2Lookup }}{% endif %}{% if reportAddress_townLookup %}, {{ reportAddress_townLookup }}{% endif %}{% if reportAddress_countyLookup %}, {{ reportAddress_countyLookup }}{% endif %}{% if reportAddress_postcodeLookup %}, {{ reportAddress_postcodeLookup }}{% endif %}<br><br>Check your address for mistakes, then try again.<br><br>Check you have entered the address correctly, then try again."
         },
         {
           "name": "searchAgain",
           "options": {},
           "type": "Html",
-          "content": "<p class=\"govuk-body-m\"><a href=\"order-risk-report-find-an-address\">Change your search</a> or <a href=\"enter-address-manually\">enter address manually</a></p>"
+          "content": "<p class=\"govuk-body-m\"><a href=\"order-risk-report-find-a-report-address{% if returnUrl %}?returnUrl={{ returnUrl | urlencode }}{% endif %}\">Change your search</a> or <a href=\"order-risk-report-enter-report-address-manually{% if returnUrl %}?returnUrl={{ returnUrl | urlencode }}{% endif %}\">enter address manually</a></p>"
         }
       ],
-      "next": [{ "path": "/enter-address-manually" }]
+      "next": [{ "path": "/order-risk-report-enter-report-address-manually" }]
     },
 
     {
@@ -489,12 +515,60 @@
           "content": "We will send your payment confirmation and the report to the email address provided."
         }
       ],
-      "next": [{ "path": "/find-a-delivery-address" }]
+      "next": [
+        {
+          "path": "/order-risk-report-is-delivery-address-same-as-report-address"
+        }
+      ]
     },
     {
-      "path": "/order-risk-report-enter-delivery-address-manual",
+      "path": "/order-risk-report-is-delivery-address-same-as-report-address",
+      "title": "Is this the correct delivery address?",
+      "components": [
+        {
+          "name": "deliveryAddressSameAsReportDisplay",
+          "type": "DisplayAddress",
+          "content": "{{ deliveryAddressSameAsReportDisplay }}"
+        },
+        {
+          "name": "deliveryAddressSameAsReport",
+          "options": {
+            "hideTitle": true,
+            "customValidationMessages": {
+              "any.required": "Select yes if your delivery address is the same as your risk report address"
+            }
+          },
+          "type": "YesNoField",
+          "title": "Is this the correct delivery address?"
+        },
+        {
+          "name": "deliveryAddressSameAsReportDisplay",
+          "options": {},
+          "type": "HiddenField",
+          "title": "Delivery address"
+        }
+      ],
+      "controller": "DeliveryAddressSameAsReportPageController",
+      "next": [
+        {
+          "path": "/summary",
+          "condition": "isDeliveryAddressSameAsReport"
+        },
+        { "path": "/order-risk-report-find-a-delivery-address" }
+      ]
+    },
+    {
+      "path": "/order-risk-report-enter-delivery-address-manually",
       "title": "Enter the delivery address for the risk report",
       "components": [
+        {
+          "name": "addressType",
+          "options": {
+            "exposeToContext": true,
+            "value": "deliveryAddress"
+          },
+          "type": "HiddenField"
+        },
         {
           "name": "postalCostNote",
           "type": "Para",
@@ -571,10 +645,21 @@
           "content": "You will receive the report to your delivery address within 3 to 5 working days."
         }
       ],
-      "next": [{ "path": "/summary" }]
+      "controller": "FindAnAddressPageController",
+      "next": [
+        {
+          "path": "/order-risk-report-is-this-the-correct-delivery-address",
+          "condition": "hasMatchedDeliveryAddressCondition"
+        },
+        { "path": "/order-risk-report-select-a-delivery-address" },
+        {
+          "path": "/order-risk-report-no-delivery-addresses-found",
+          "condition": "noDeliveryAddressesCondition"
+        }
+      ]
     },
     {
-      "path": "/find-a-delivery-address",
+      "path": "/order-risk-report-find-a-delivery-address",
       "title": "What is the delivery address for your risk report?",
       "components": [
         {
@@ -633,24 +718,24 @@
           "name": "enterManuallyLink",
           "options": {},
           "type": "Html",
-          "content": "<br><a href=\"order-risk-report-enter-delivery-address-manual\">Enter address manually</a>"
+          "content": "<br><a href=\"order-risk-report-enter-delivery-address-manually{% if returnUrl %}?returnUrl={{ returnUrl | urlencode }}{% endif %}\">Enter address manually</a>"
         }
       ],
       "controller": "FindAnAddressPageController",
       "next": [
         {
-          "path": "/is-this-the-correct-delivery-address",
+          "path": "/order-risk-report-is-this-the-correct-delivery-address",
           "condition": "hasMatchedDeliveryAddressCondition"
         },
         {
-          "path": "/no-delivery-addresses-found",
+          "path": "/order-risk-report-no-delivery-addresses-found",
           "condition": "noDeliveryAddressesCondition"
         },
-        { "path": "/select-a-delivery-address" }
+        { "path": "/order-risk-report-select-a-delivery-address" }
       ]
     },
     {
-      "path": "/is-this-the-correct-delivery-address",
+      "path": "/order-risk-report-is-this-the-correct-delivery-address",
       "title": "Is this the correct address?",
       "components": [
         {
@@ -693,14 +778,14 @@
       ],
       "controller": "SelectAnAddressPageController",
       "options": {
-        "changePath": "/find-a-delivery-address"
+        "changePath": "/order-risk-report-find-a-delivery-address"
       },
       "componentsAfter": [
         {
           "name": "enterManuallyLink",
           "options": {},
           "type": "Html",
-          "content": "<br><a href=\"order-risk-report-enter-delivery-address-manual\">Enter address manually</a>"
+          "content": "<br><a href=\"order-risk-report-enter-delivery-address-manually{% if returnUrl %}?returnUrl={{ returnUrl | urlencode }}{% endif %}\">Enter address manually</a>"
         }
       ],
       "next": [
@@ -708,11 +793,15 @@
           "path": "/summary",
           "condition": "isCorrectDeliveryAddress"
         },
-        { "path": "/select-a-delivery-address" }
+        {
+          "path": "/order-risk-report-no-delivery-addresses-found",
+          "condition": "deliveryAddressOnlyOneAddressCondition"
+        },
+        { "path": "/order-risk-report-select-a-delivery-address" }
       ]
     },
     {
-      "path": "/select-a-delivery-address",
+      "path": "/order-risk-report-select-a-delivery-address",
       "title": "Select a delivery address",
       "components": [
         {
@@ -725,7 +814,7 @@
           "name": "searchAgain",
           "options": {},
           "type": "Html",
-          "content": "<p class=\"govuk-body-m\"><a href=\"find-a-delivery-address\">Change your search</a> if the address you're looking for is not listed.</p>"
+          "content": "<p class=\"govuk-body-m\"><a href=\"order-risk-report-find-a-delivery-address{% if returnUrl %}?returnUrl={{ returnUrl | urlencode }}{% endif %}\">Change your search</a> if the address you're looking for is not listed.</p>"
         },
         {
           "name": "addressType",
@@ -750,21 +839,26 @@
       ],
       "controller": "SelectAnAddressPageController",
       "options": {
-        "changePath": "/find-a-delivery-address"
+        "changePath": "/order-risk-report-find-a-delivery-address"
       },
-      "next": [{ "path": "/summary" }],
+      "next": [
+        { "path": "/order-risk-report-is-this-the-correct-delivery-address" }
+      ],
       "componentsAfter": [
         {
           "name": "enterManuallyLink",
           "options": {},
           "type": "Html",
-          "content": "<br><a href=\"order-risk-report-enter-delivery-address-manual\">Enter address manually</a>"
+          "content": "<br><a href=\"order-risk-report-enter-delivery-address-manually{% if returnUrl %}?returnUrl={{ returnUrl | urlencode }}{% endif %}\">Enter address manually</a>"
         }
       ]
     },
     {
-      "path": "/no-delivery-addresses-found",
-      "title": "No addresses found for {{ deliveryAddress_postcodeLookup }} and {{ deliveryAddress_buildingLookup }}",
+      "path": "/order-risk-report-no-delivery-addresses-found",
+      "title": "No addresses found for ‘{{ deliveryAddress_postcodeLookup }}’ and ‘{{ deliveryAddress_buildingLookup }}’",
+      "options": {
+        "hideContinueButton": true
+      },
       "components": [
         {
           "name": "noAddressesFoundMessage",
@@ -776,10 +870,16 @@
           "name": "searchAgain",
           "options": {},
           "type": "Html",
-          "content": "<p class=\"govuk-body-m\"><a href=\"find-a-delivery-address\">Change your search</a> or <a href=\"order-risk-report-enter-delivery-address-manual\">enter address manually</a></p>"
+          "content": "<p class=\"govuk-body-m\"><a href=\"order-risk-report-find-a-delivery-address{% if returnUrl %}?returnUrl={{ returnUrl | urlencode }}{% endif %}\">Change your search</a> or <a href=\"order-risk-report-enter-delivery-address-manually{% if returnUrl %}?returnUrl={{ returnUrl | urlencode }}{% endif %}\">enter address manually</a></p>"
         }
       ],
-      "next": [{ "path": "/find-a-delivery-address" }]
+      "next": [
+        { "path": "/order-risk-report-find-a-delivery-address" },
+        {
+          "path": "/order-risk-report-enter-delivery-address-manually",
+          "condition": "deliveryAddressEnteredManuallyCondition"
+        }
+      ]
     },
     {
       "title": "Check your answers",
@@ -917,6 +1017,24 @@
       }
     },
     {
+      "name": "reportAddressOnlyOneAddressCondition",
+      "displayName": "Report Address Only One Address Found",
+      "value": {
+        "name": "reportAddressOnlyOneAddressCondition",
+        "conditions": [
+          {
+            "field": {
+              "name": "reportAddress_numberOfAddresses",
+              "type": "NumberField",
+              "display": "numberOfAddresses"
+            },
+            "operator": "is",
+            "value": { "type": "Value", "value": "1", "display": "1" }
+          }
+        ]
+      }
+    },
+    {
       "name": "hasMatchedDeliveryAddressCondition",
       "displayName": "Has Matched Delivery Address",
       "value": {
@@ -935,6 +1053,42 @@
       }
     },
     {
+      "name": "reportAddressEnteredManuallyCondition",
+      "displayName": "Report Address Entered Manually",
+      "value": {
+        "name": "reportAddressEnteredManuallyCondition",
+        "conditions": [
+          {
+            "field": {
+              "name": "reportAddress_addressLine1Lookup",
+              "type": "TextField",
+              "display": "reportAddressEnteredManually"
+            },
+            "operator": "is longer than",
+            "value": { "type": "Value", "value": "0", "display": "0" }
+          }
+        ]
+      }
+    },
+    {
+      "name": "deliveryAddressEnteredManuallyCondition",
+      "displayName": "Delivery Address Entered Manually",
+      "value": {
+        "name": "deliveryAddressEnteredManuallyCondition",
+        "conditions": [
+          {
+            "field": {
+              "name": "deliveryAddress_addressLine1Lookup",
+              "type": "TextField",
+              "display": "deliveryAddressEnteredManually"
+            },
+            "operator": "is longer than",
+            "value": { "type": "Value", "value": "0", "display": "0" }
+          }
+        ]
+      }
+    },
+    {
       "name": "noDeliveryAddressesCondition",
       "displayName": "No Addresses Found",
       "value": {
@@ -948,6 +1102,24 @@
             },
             "operator": "is",
             "value": { "type": "Value", "value": "0", "display": "0" }
+          }
+        ]
+      }
+    },
+    {
+      "name": "deliveryAddressOnlyOneAddressCondition",
+      "displayName": "Delivery Address Only One Address Found",
+      "value": {
+        "name": "deliveryAddressOnlyOneAddressCondition",
+        "conditions": [
+          {
+            "field": {
+              "name": "deliveryAddress_numberOfAddresses",
+              "type": "NumberField",
+              "display": "numberOfAddresses"
+            },
+            "operator": "is",
+            "value": { "type": "Value", "value": "1", "display": "1" }
           }
         ]
       }
@@ -987,6 +1159,24 @@
           }
         ]
       }
+    },
+    {
+      "displayName": "Delivery Address Same As Report Address",
+      "name": "isDeliveryAddressSameAsReport",
+      "value": {
+        "name": "isDeliveryAddressSameAsReport",
+        "conditions": [
+          {
+            "field": {
+              "name": "deliveryAddressSameAsReport",
+              "type": "YesNoField",
+              "display": "deliveryAddressSameAsReport"
+            },
+            "operator": "is",
+            "value": { "type": "Value", "value": "true", "display": "true" }
+          }
+        ]
+      }
     }
   ],
   "summaryConfig": {
@@ -997,6 +1187,17 @@
       "errorMessage": "You must accept the Privacy Policy and Terms and Conditions before continuing"
     },
     "mergeFields": [
+      {
+        "names": [
+          "reportAddress_addressLine1Lookup",
+          "reportAddress_addressLine2Lookup",
+          "reportAddress_townLookup",
+          "reportAddress_countyLookup",
+          "reportAddress_postcodeLookup"
+        ],
+        "to": "Risk report address",
+        "joiner": ", "
+      },
       {
         "names": [
           "deliveryAddress_addressLine1Lookup",
@@ -1026,7 +1227,8 @@
       "deliveryAddress_countyLookup",
       "deliveryAddress_isCorrectAddress",
 
-      "addressType"
+      "addressType",
+      "deliveryAddressSameAsReport"
     ],
     "relabelFields": {
       "deliveryMethod": "Delivery method",
@@ -1062,6 +1264,13 @@
       {
         "when": { "field": "emailAddress", "isEmpty": true },
         "removeFields": ["emailAddress"]
+      },
+      {
+        "when": {
+          "field": "deliveryAddressSameAsReportDisplay",
+          "isEmpty": true
+        },
+        "removeFields": ["deliveryAddressSameAsReportDisplay"]
       }
     ]
   },

--- a/runner/src/server/plugins/engine/components/DisplayAddress.ts
+++ b/runner/src/server/plugins/engine/components/DisplayAddress.ts
@@ -1,27 +1,22 @@
-import { ComponentBase } from "./ComponentBase";
 import { FormData, FormSubmissionErrors } from "../types";
-import config from "../../../config";
 import nunjucks from "nunjucks";
+import { Para } from "./Para";
 
-export class DisplayAddress extends ComponentBase {
+export class DisplayAddress extends Para {
   getViewModel(formData: FormData, errors: FormSubmissionErrors) {
     const options: any = this.options;
 
-    let content = this.content;
-  
-    if (config.allowUserTemplates) {
-      content = nunjucks.renderString(content, { ...formData });
-    }
+    const content = nunjucks.renderString(this.content, { ...formData });
 
-    const displayAddress = content.replaceAll(",", "<br>");
     const viewModel = {
       ...super.getViewModel(formData, errors),
-      content: displayAddress,
+      content,
     };
 
     if (options.condition) {
       viewModel.condition = options.condition;
     }
+
     return viewModel;
   }
 }

--- a/runner/src/server/plugins/engine/components/TextField.ts
+++ b/runner/src/server/plugins/engine/components/TextField.ts
@@ -65,17 +65,13 @@ export class TextField extends FormComponent {
   }
 
   format(options: any, value: string) {
-    console.log("formatting value: ", value, " with options: ", options);
-    if (options?.trim === true) {
-      console.log("trimming content: ", value);
+    if (options?.trim) {
       value = value.trim();
     }
 
     if (options?.case === "upper") {
-      console.log("converting content to upper case: ", value);
       value = value.toUpperCase();
     } else if (options?.case === "lower") {
-      console.log("converting content to lower case: ", value);
       value = value.toLowerCase();
     }
 
@@ -90,7 +86,7 @@ export class TextField extends FormComponent {
     let value;
     if (payload) {
       value = this.getStateValueFromValidForm(payload);
-      if(value) {    
+      if (value) {
         if (options.format) {
           value = this.format(options.format, value);
           payload[this.name] = value;

--- a/runner/src/server/plugins/engine/helpers.ts
+++ b/runner/src/server/plugins/engine/helpers.ts
@@ -8,6 +8,12 @@ export const feedbackReturnInfoKey = "f_t";
 
 const paramsToCopy = [feedbackReturnInfoKey, "returnUrl"];
 
+/**
+ * Checks if the url is internal
+ */
+const isSafeInternalUrl = (url: string): boolean =>
+  url.startsWith("/") && !url.startsWith("//");
+
 export function proceed(
   request: HapiRequest,
   h: HapiResponseToolkit,
@@ -19,7 +25,7 @@ export function proceed(
   if (
     honourReturnUrl &&
     typeof returnUrl === "string" &&
-    returnUrl.startsWith("/")
+    isSafeInternalUrl(returnUrl)
   ) {
     return h.redirect(returnUrl);
   } else {
@@ -40,11 +46,22 @@ export function getBackLink(
 ) {
   const returnUrl = request.query.returnUrl;
 
-  if (typeof returnUrl === "string" && returnUrl.startsWith("/")) {
+  if (typeof returnUrl === "string" && isSafeInternalUrl(returnUrl)) {
     return returnUrl;
   }
 
   return progress[progress.length - 2] ?? backLinkFallback;
+}
+
+/**
+ * Returns the current request's `returnUrl` query param if it's present.
+ */
+export function getReturnUrl(request: HapiRequest): string | undefined {
+  const returnUrl = request.query.returnUrl;
+
+  return typeof returnUrl === "string" && isSafeInternalUrl(returnUrl)
+    ? returnUrl
+    : undefined;
 }
 
 type Params = { num?: number; returnUrl: string } | {};

--- a/runner/src/server/plugins/engine/models/FormModel.ts
+++ b/runner/src/server/plugins/engine/models/FormModel.ts
@@ -103,8 +103,6 @@ export class FormModel {
     this.name = def.name;
     this.serviceStartPage =
       def.fullStartPage || config.serviceStartPage || config.serviceName || "#";
-    this.serviceStartPage =
-      def.fullStartPage || config.serviceStartPage || config.serviceName || "#";
     this.returnTo = def.returnTo || false;
     this.values = result.value;
 

--- a/runner/src/server/plugins/engine/pageControllers/DeliveryAddressSameAsReportPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/DeliveryAddressSameAsReportPageController.ts
@@ -1,0 +1,68 @@
+import { PageControllerBase } from "./PageControllerBase";
+import { HapiRequest, HapiResponseToolkit } from "server/types";
+import { formatAddress } from "../utils/addressUtils";
+
+const COMPONENT_SAME_AS_REPORT = "deliveryAddressSameAsReport";
+const COMPONENT_DISPLAY = "deliveryAddressSameAsReportDisplay";
+
+export class DeliveryAddressSameAsReportPageController extends PageControllerBase {
+  private displayAddress: string = "";
+
+  async getRouteHandlerHook(request: HapiRequest) {
+    const { cacheService } = request.services([]);
+    const currentState = await cacheService.getState(request);
+    this.displayAddress = `${currentState.reportAddress_selectedAddress.address}, ${currentState.reportAddress_selectedAddress.postcode}`;
+  }
+
+  getViewModel(formData: any, iteration?: any, errors?: any) {
+    const viewModel = super.getViewModel(formData, iteration, errors);
+
+    const displayIndex = this.components.items.findIndex(
+      (c: any) => c.name === COMPONENT_DISPLAY
+    );
+
+    if (displayIndex !== -1 && viewModel.components[displayIndex]?.model) {
+      viewModel.components[displayIndex].model.content = this.displayAddress;
+    }
+
+    return viewModel;
+  }
+
+  makePostRouteHandler() {
+    return async (request: HapiRequest, h: HapiResponseToolkit) => {
+      const response = await this.handlePostRequest(request, h);
+      if (response?.source?.context?.errors) {
+        return response;
+      }
+
+      const payload = (request.payload || {}) as Record<string, unknown>;
+      const sameAsReport = payload[COMPONENT_SAME_AS_REPORT] === "true";
+
+      const { cacheService } = request.services([]);
+      const currentState = await cacheService.getState(request);
+
+      if (sameAsReport) {
+        const reportAddress = currentState.reportAddress_selectedAddress;
+
+        const savedState = await cacheService.mergeState(request, {
+          [COMPONENT_SAME_AS_REPORT]: true,
+          deliveryAddress_selectedAddress: reportAddress,
+          deliveryAddress_matchedAddress: reportAddress,
+          deliveryAddress_isCorrectAddress: true,
+          [COMPONENT_DISPLAY]: reportAddress
+            ? formatAddress(reportAddress)
+            : "",
+        });
+
+        return this.proceed(request, h, savedState, true);
+      }
+
+      const savedState = await cacheService.mergeState(request, {
+        [COMPONENT_SAME_AS_REPORT]: false,
+        [COMPONENT_DISPLAY]: null,
+      });
+
+      return this.proceed(request, h, savedState, false);
+    };
+  }
+}

--- a/runner/src/server/plugins/engine/pageControllers/FindAnAddressPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/FindAnAddressPageController.ts
@@ -8,50 +8,9 @@ import {
   addressesToList,
   AddressType,
   deriveSelectedFieldName,
+  findMatchingAddress,
+  cleanAddresses,
 } from "../utils/addressUtils";
-
-const STREET_NUMBER_PATTERN = /(^|, )(\d+[A-Z]?([-\/]\d+)?[A-Z]?),/i;
-
-const findMatchingAddress = (
-  addresses: any[],
-  building?: string,
-  addressLine1?: string
-): any | null => {
-  const normalizedBuilding = building?.trim().toUpperCase();
-  const addressLine1Pattern = addressLine1
-    ? new RegExp(`^${addressLine1.trim().toUpperCase()}( |,)`)
-    : null;
-
-  for (const address of addresses) {
-    const firstPart = address.address.split(",")[0].trim().toUpperCase();
-
-    if (normalizedBuilding) {
-      if (
-        firstPart.replace(/\s/g, "") ===
-          normalizedBuilding.replace(/\s/g, "") ||
-        firstPart.startsWith(normalizedBuilding + " ")
-      ) {
-        return address;
-      }
-    }
-
-    if (
-      addressLine1Pattern &&
-      addressLine1Pattern.test(address.address.toUpperCase())
-    ) {
-      return address;
-    }
-  }
-
-  return null;
-};
-
-const cleanAddresses = (addresses: any[]): any[] => {
-  return addresses.map((address) => ({
-    ...address,
-    address: address.address.replace(STREET_NUMBER_PATTERN, "$1$2"),
-  }));
-};
 
 const formSchema = Joi.object({
   addressType: addressTypeSchema,
@@ -123,6 +82,7 @@ export class FindAnAddressPageController extends PageControllerBase {
 
       const addresses = cleanAddresses(addressResponse.addresses);
 
+      // TODO:- "Fuzzy check full address" integration point
       const matchedAddress = findMatchingAddress(
         addresses,
         buildingLookup,
@@ -155,7 +115,7 @@ export class FindAnAddressPageController extends PageControllerBase {
 
       // This is always an intermediate step of the address-lookup
       // sub-journey, never a completion, so it must never short-circuit
-      // straight to a Change link's returnUrl.
+      // straight to a Change link's returnUrl so honourReturnUrl is false.
       return this.proceed(request, h, { ...savedState }, false);
     };
   }

--- a/runner/src/server/plugins/engine/pageControllers/FindAnAddressPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/FindAnAddressPageController.ts
@@ -105,7 +105,7 @@ export class FindAnAddressPageController extends PageControllerBase {
         // save data
         [`${addressType}_addresses`]: addresses,
         [`${addressType}_numberOfAddresses`]: addresses.length,
-        [`${addressType}_hasMatchedAddress`]: matchedAddress !== null,
+        [`${addressType}_hasMatchedAddress`]: matchedAddress !== undefined,
         [`${addressType}_matchedAddress`]: matchedAddress,
         [`${addressType}_isCorrectAddress`]: null,
         // clear any selection made against a previous search's results

--- a/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -616,10 +616,6 @@ export class PageControllerBase {
         });
       }
       const viewModel = this.getViewModel(formData, num);
-      // DEBUG: dumps the full session state to the browser console on every
-      // page render, for every form - see layout.html bodyEnd block. Remove
-      // before shipping.
-      viewModel.debugSessionState = state;
       viewModel.startPage = startPage!.startsWith("http")
         ? redirectTo(request, h, startPage!)
         : redirectTo(request, h, `/${this.model.basePath}${startPage!}`);
@@ -985,16 +981,9 @@ export class PageControllerBase {
   ) {
     const nextPage = this.getNext(state);
     const nextUrl = nextPage?.redirect ?? nextPage;
-    /**
-     * When a controller doesn't know its own branching well enough to say
-     * whether honouring a Change link's returnUrl is safe, only honour it if
-     * the page we're actually about to visit next is the returnUrl itself -
-     * i.e. this really was the last step before getting back there. This
-     * stops pages with conditional `next` branches (e.g. a delivery method
-     * choice that can lead to a much longer sub-journey) from skipping
-     * required pages when reached via a Change link.
-     */
+
     const returnUrl = getReturnUrl(request);
+
     const shouldHonourReturnUrl =
       honourReturnUrl ??
       (typeof nextUrl === "string" &&

--- a/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/runner/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -5,6 +5,7 @@ import { validationOptions } from "server/plugins/engine/pageControllers/validat
 import {
   feedbackReturnInfoKey,
   getBackLink,
+  getReturnUrl,
   proceed,
   redirectTo,
 } from "../helpers";
@@ -74,6 +75,7 @@ export class PageControllerBase {
   disableBackLink?: boolean;
   returnUrl?: string;
   buttonText?: string;
+  hideContinueButton?: boolean;
 
   // TODO: pageDef type
   constructor(model: FormModel, pageDef: { [prop: string]: any } = {}) {
@@ -94,6 +96,7 @@ export class PageControllerBase {
     this.disableSingleComponentAsHeading =
       pageDef.disableSingleComponentAsHeading;
     this.buttonText = pageDef.customButtonText ?? this.defaultButtonText;
+    this.hideContinueButton = pageDef.options?.hideContinueButton ?? false;
 
     // Resolve section
     this.section = model.sections?.find(
@@ -378,7 +381,23 @@ export class PageControllerBase {
         ),
       };
     } else {
+      // get component names
+      const ownFieldNames = new Set(
+        this.components.formItems.map((item) => item.name)
+      );
+
+      // extract state values matching component state names
+      const rawState = Object.fromEntries(
+        Object.entries(pageState || {}).filter(
+          ([key, v]) =>
+            ownFieldNames.has(key) &&
+            (typeof v === "string" ||
+              typeof v === "number" ||
+              typeof v === "boolean")
+        )
+      );
       formData = {
+        ...rawState,
         ...this.components.getFormDataFromState(pageState || {}),
         ...this.model.getContextState(state),
       };
@@ -472,7 +491,7 @@ export class PageControllerBase {
     let nextPage = model.startPage;
 
     //While the current page isn't null
-    const checkedPages: any[] = [];
+    const checkedPages = new Set<any>();
     while (nextPage != null) {
       //Either get the current state or the current state of the section if this page belongs to a section
       const currentState =
@@ -509,10 +528,10 @@ export class PageControllerBase {
       }
 
       //If a nextPage is returned, we must have taken that route through the form so continue our iteration with the new page
-      if (checkedPages.includes(nextPage)) {
+      if (checkedPages.has(nextPage)) {
         nextPage = null;
       } else {
-        checkedPages.push(nextPage);
+        checkedPages.add(nextPage);
       }
     }
 
@@ -584,6 +603,7 @@ export class PageControllerBase {
       }
 
       formData.lang = lang;
+      formData.returnUrl = getReturnUrl(request);
       /**
        * We store the original filename for the user in a separate object (`originalFileNames`), however they are not used for any of the outputs. The S3 url is stored in the state.
        */
@@ -596,6 +616,10 @@ export class PageControllerBase {
         });
       }
       const viewModel = this.getViewModel(formData, num);
+      // DEBUG: dumps the full session state to the browser console on every
+      // page render, for every form - see layout.html bodyEnd block. Remove
+      // before shipping.
+      viewModel.debugSessionState = state;
       viewModel.startPage = startPage!.startsWith("http")
         ? redirectTo(request, h, startPage!)
         : redirectTo(request, h, `/${this.model.basePath}${startPage!}`);
@@ -720,6 +744,7 @@ export class PageControllerBase {
     const { num } = request.query;
     const formData = this.getFormDataFromState(state, num - 1);
     const combined = { ...formData, ...payload } as FormData;
+    combined.returnUrl = getReturnUrl(request);
 
     // TODO:- Refactor this into a validation method
     if (hasFilesizeError) {
@@ -956,13 +981,27 @@ export class PageControllerBase {
     request: HapiRequest,
     h: HapiResponseToolkit,
     state,
-    honourReturnUrl: boolean = true
+    honourReturnUrl?: boolean
   ) {
     const nextPage = this.getNext(state);
-    if (nextPage?.redirect) {
-      return proceed(request, h, nextPage?.redirect, honourReturnUrl);
-    }
-    return proceed(request, h, nextPage, honourReturnUrl);
+    const nextUrl = nextPage?.redirect ?? nextPage;
+    /**
+     * When a controller doesn't know its own branching well enough to say
+     * whether honouring a Change link's returnUrl is safe, only honour it if
+     * the page we're actually about to visit next is the returnUrl itself -
+     * i.e. this really was the last step before getting back there. This
+     * stops pages with conditional `next` branches (e.g. a delivery method
+     * choice that can lead to a much longer sub-journey) from skipping
+     * required pages when reached via a Change link.
+     */
+    const returnUrl = getReturnUrl(request);
+    const shouldHonourReturnUrl =
+      honourReturnUrl ??
+      (typeof nextUrl === "string" &&
+        returnUrl !== undefined &&
+        nextUrl.split("?")[0] === returnUrl.split("?")[0]);
+
+    return proceed(request, h, nextUrl, shouldHonourReturnUrl);
   }
 
   getPartialMergeState(value) {

--- a/runner/src/server/plugins/engine/pageControllers/SelectAnAddressPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/SelectAnAddressPageController.ts
@@ -8,6 +8,7 @@ import {
   SelectedFieldName,
   deriveSelectedFieldName,
   formatAddress,
+  resolveAddressByUprn,
 } from "../utils/addressUtils";
 
 type FormSubmission = {
@@ -188,6 +189,7 @@ export class SelectAnAddressPageController extends PageControllerBase {
       const currentState = await cacheService.getState(request);
 
       if (isCorrectAddress) {
+        // TODO:- "Address check in DB" integration point
         const resolvedSelectedAddress =
           isCorrectAddress === "true"
             ? currentState[`${addressType}_matchedAddress`]
@@ -205,19 +207,24 @@ export class SelectAnAddressPageController extends PageControllerBase {
           }),
         });
 
-        // Only a "Yes" answer is a genuine completion of the address
-        // sub-journey; "No" must continue on to select-an-address per the
-        // normal `next` config, even if a Change link's returnUrl is present.
         const honourReturnUrl = isCorrectAddress === "true";
         return this.proceed(request, h, savedState, honourReturnUrl);
       }
 
+      const addresses: any[] = currentState[`${addressType}_addresses`] || [];
+
+      const resolvedMatchedAddress = resolveAddressByUprn(
+        addresses,
+        selectedAddress
+      );
+
       const savedState = await cacheService.mergeState(request, {
-        [`${addressType}_isCorrectAddress`]: false,
+        [`${addressType}_isCorrectAddress`]: null,
         [`${addressType}_selectedAddress`]: selectedAddress,
+        [`${addressType}_matchedAddress`]: resolvedMatchedAddress,
       });
 
-      return this.proceed(request, h, savedState);
+      return this.proceed(request, h, savedState, false);
     };
   }
 }

--- a/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -50,30 +50,44 @@ export class SummaryPageController extends PageController {
         const errorToFix = viewModel.errors[0];
         const { path } = errorToFix;
         const parts = path.split(".");
-        const section = parts[0];
-        const property = parts.length > 1 ? parts[parts.length - 1] : null;
+        const property = parts.length > 1 ? parts[parts.length - 1] : parts[0];
+
+        const sectionName = parts.length > 1 ? parts[0] : null;
+
         const iteration = parts.length === 3 ? Number(parts[1]) + 1 : null;
-        const pageWithError = model.pages.filter((page) => {
-          if (page.section && page.section.name === section) {
-            let propertyMatches = true;
-            let conditionMatches = true;
-            if (property) {
-              propertyMatches =
-                page.components.formItems.filter(
-                  (item) => item.name === property
-                ).length > 0;
-            }
-            if (
-              propertyMatches &&
-              page.condition &&
-              model.conditions[page.condition]
-            ) {
-              conditionMatches = model.conditions[page.condition].fn(state);
-            }
-            return propertyMatches && conditionMatches;
+
+        const candidatePages = model.pages.filter((page) => {
+          const sectionMatches = page.section
+            ? page.section.name === sectionName
+            : sectionName === null;
+
+          if (!sectionMatches) return false;
+
+          let propertyMatches = true;
+          let conditionMatches = true;
+          if (property) {
+            propertyMatches =
+              page.components.formItems.filter((item) => item.name === property)
+                .length > 0;
           }
-          return false;
-        })[0];
+
+          if (
+            propertyMatches &&
+            page.condition &&
+            model.conditions[page.condition]
+          ) {
+            conditionMatches = model.conditions[page.condition].fn(state);
+          }
+
+          return propertyMatches && conditionMatches;
+        });
+
+        const pageWithError =
+          candidatePages.find(
+            (page) =>
+              page.condition && model.conditions[page.condition]?.fn(state)
+          ) ?? candidatePages[0];
+
         if (pageWithError) {
           const params = {
             returnUrl: redirectUrl(request, `/${model.basePath}/summary`),
@@ -186,12 +200,6 @@ export class SummaryPageController extends PageController {
         outputs: summaryViewModel.outputs,
         userCompletedSummary: true,
       });
-
-      // Commented out due to potential for logging PII
-      // request.logger.info(
-      //   ["Webhook data", "before send", request.yar.id],
-      //   JSON.stringify(summaryViewModel.validatedWebhookData)
-      // );
 
       await cacheService.mergeState(request, {
         webhookData: summaryViewModel.validatedWebhookData,
@@ -320,11 +328,11 @@ export class SummaryPageController extends PageController {
 
   get payApiKey(): string {
     const modelDef = this.model.def;
-    const payApiKey = modelDef.feeOptions?.payApiKey ?? def.payApiKey;
+    const payApiKey = modelDef.feeOptions?.payApiKey ?? modelDef.payApiKey;
 
     if (isMultipleApiKey(payApiKey)) {
       return payApiKey[config.apiEnv] ?? payApiKey.test ?? payApiKey.production;
     }
-    return payApiKey;
+    return payApiKey ?? "";
   }
 }

--- a/runner/src/server/plugins/engine/pageControllers/helpers.ts
+++ b/runner/src/server/plugins/engine/pageControllers/helpers.ts
@@ -23,6 +23,7 @@ import { DateComparisonPageController } from "./DateComparisonPageController";
 import { MagicLinkRedirectController } from "./MagicLinkRedirectController";
 import { FindAnAddressPageController } from "./FindAnAddressPageController";
 import { SelectAnAddressPageController } from "./SelectAnAddressPageController";
+import { DeliveryAddressSameAsReportPageController } from "./DeliveryAddressSameAsReportPageController";
 
 const PageControllers = {
   DobPageController,
@@ -47,6 +48,7 @@ const PageControllers = {
   MagicLinkRedirectController,
   FindAnAddressPageController,
   SelectAnAddressPageController,
+  DeliveryAddressSameAsReportPageController,
 };
 
 export const controllerNameFromPath = (filePath: string) => {

--- a/runner/src/server/plugins/engine/types.ts
+++ b/runner/src/server/plugins/engine/types.ts
@@ -77,6 +77,7 @@ export type FormPayload = {
 
 export type FormData = {
   lang?: string; // form language e.g: "en"
+  returnUrl?: string; // present when reached via a summary page's "Change" link
   value?: FormPayload;
   errors?: FormSubmissionErrors | null;
 };

--- a/runner/src/server/plugins/engine/utils/addressUtils.ts
+++ b/runner/src/server/plugins/engine/utils/addressUtils.ts
@@ -1,5 +1,6 @@
 import { Item } from "@xgovformbuilder/model/dist/module/data-model/types";
 import Joi from "joi";
+import { Address } from "src/server/services/addressLookupService";
 
 export type AddressType = "reportAddress" | "deliveryAddress";
 
@@ -12,14 +13,29 @@ export const addressTypeSchema = Joi.string().valid(
   "deliveryAddress"
 );
 
+/**
+ * Returns the selected address name using the address type
+ * @param addressType - the adders type
+ * @returns the component name of the selected address
+ */
 export function deriveSelectedFieldName(
   addressType: AddressType
 ): SelectedFieldName {
-  return addressType === "deliveryAddress"
-    ? "selectedDeliveryAddress"
-    : "selectedReportAddress";
+  switch (addressType) {
+    case "reportAddress":
+      return "selectedReportAddress";
+    case "deliveryAddress":
+      return "selectedDeliveryAddress";
+    default:
+      return addressType as never;
+  }
 }
 
+/**
+ * Converts an array of addresses to a template list
+ * @param addresses - a list of addresses
+ * @returns the address list template
+ */
 export const addressesToList = (addresses: Address[]): Item[] => {
   return addresses.map((address) => ({
     text: address.address,
@@ -27,27 +43,48 @@ export const addressesToList = (addresses: Address[]): Item[] => {
   }));
 };
 
-export const formatAddress = (addr: {
+/**
+ * Formats the address object from the lookup api
+ * @param address - an address object
+ * @returns a single line comma-separated address
+ */
+export const formatAddress = (address: {
   address: string;
   postcode?: string;
 }): string => {
-  return addr.postcode ? `${addr.address}, ${addr.postcode}` : addr.address;
+  return address.postcode
+    ? `${address.address}, ${address.postcode}`
+    : address.address;
 };
 
+/**
+ * Finds an address by UPRN
+ * @param addresses - a list of addresses
+ * @param uprn - the uprn
+ * @returns an address or undefined
+ */
 export const resolveAddressByUprn = (
-  addresses: any[],
-  uprn: unknown
-): any | null => {
-  return addresses.find((addr) => String(addr.uprn) === String(uprn)) ?? null;
+  addresses: Address[],
+  uprn: Address["uprn"]
+): Address | undefined => {
+  return addresses.find((addr) => String(addr.uprn) === uprn);
 };
 
 const STREET_NUMBER_PATTERN = /(^|, )(\d+[A-Z]?([-\/]\d+)?[A-Z]?),/i;
 
+/**
+ * Finds the correct address using building name, number or 1st line of address
+ *
+ * @param addresses - a list of addresses
+ * @param building - the building name
+ * @param addressLine1 - the 1st line of the address
+ * @returns an address or undefined
+ */
 export const findMatchingAddress = (
-  addresses: any[],
+  addresses: Address[],
   building?: string,
   addressLine1?: string
-): any | null => {
+): Address | undefined => {
   const normalizedBuilding = building?.trim().toUpperCase();
   const addressLine1Pattern = addressLine1
     ? new RegExp(`^${addressLine1.trim().toUpperCase()}( |,)`)
@@ -74,10 +111,15 @@ export const findMatchingAddress = (
     }
   }
 
-  return null;
+  return undefined;
 };
 
-export const cleanAddresses = (addresses: any[]): any[] => {
+/**
+ * Cleans the address street number
+ * @param addresses - a list of addresses
+ * @returns a transformed address
+ */
+export const cleanAddresses = (addresses: Address[]): Address[] => {
   return addresses.map((address) => ({
     ...address,
     address: address.address.replace(STREET_NUMBER_PATTERN, "$1$2"),

--- a/runner/src/server/plugins/engine/utils/addressUtils.ts
+++ b/runner/src/server/plugins/engine/utils/addressUtils.ts
@@ -1,7 +1,4 @@
-import {
-  Address,
-  Item,
-} from "@xgovformbuilder/model/dist/module/data-model/types";
+import { Item } from "@xgovformbuilder/model/dist/module/data-model/types";
 import Joi from "joi";
 
 export type AddressType = "reportAddress" | "deliveryAddress";
@@ -35,4 +32,54 @@ export const formatAddress = (addr: {
   postcode?: string;
 }): string => {
   return addr.postcode ? `${addr.address}, ${addr.postcode}` : addr.address;
+};
+
+export const resolveAddressByUprn = (
+  addresses: any[],
+  uprn: unknown
+): any | null => {
+  return addresses.find((addr) => String(addr.uprn) === String(uprn)) ?? null;
+};
+
+const STREET_NUMBER_PATTERN = /(^|, )(\d+[A-Z]?([-\/]\d+)?[A-Z]?),/i;
+
+export const findMatchingAddress = (
+  addresses: any[],
+  building?: string,
+  addressLine1?: string
+): any | null => {
+  const normalizedBuilding = building?.trim().toUpperCase();
+  const addressLine1Pattern = addressLine1
+    ? new RegExp(`^${addressLine1.trim().toUpperCase()}( |,)`)
+    : null;
+
+  for (const address of addresses) {
+    const firstPart = address.address.split(",")[0].trim().toUpperCase();
+
+    if (normalizedBuilding) {
+      if (
+        firstPart.replace(/\s/g, "") ===
+          normalizedBuilding.replace(/\s/g, "") ||
+        firstPart.startsWith(normalizedBuilding + " ")
+      ) {
+        return address;
+      }
+    }
+
+    if (
+      addressLine1Pattern &&
+      addressLine1Pattern.test(address.address.toUpperCase())
+    ) {
+      return address;
+    }
+  }
+
+  return null;
+};
+
+export const cleanAddresses = (addresses: any[]): any[] => {
+  return addresses.map((address) => ({
+    ...address,
+    address: address.address.replace(STREET_NUMBER_PATTERN, "$1$2"),
+  }));
 };

--- a/runner/src/server/plugins/engine/views/components/displayaddress.html
+++ b/runner/src/server/plugins/engine/views/components/displayaddress.html
@@ -1,3 +1,3 @@
 {% macro DisplayAddress(component) %}
-  <p class="govuk-body">{{ component.model.content | safe }}</p>
+  <p class="govuk-body">{{ component.model.content | replace(", ", "<br>") | replace(",", "<br>") | safe }}</p>
 {% endmacro %}

--- a/runner/src/server/plugins/engine/views/partials/form.html
+++ b/runner/src/server/plugins/engine/views/partials/form.html
@@ -15,7 +15,7 @@
     {{ govukSummaryList(details) }}
   {% endif %}
 
-  {% if not (components[0].type == "FlashCard") %}
+  {% if not (components[0].type == "FlashCard") and not page.hideContinueButton %}
     {% if page.isRepeatingFieldPageController and page.isSamePageDisplayMode %}
     {% if details.rows.length %}
     {{ govukButton({ attributes: { id: "submit" }, text: page.buttonText if page.buttonText else "Continue", name: "next", value: "continue"}) }}

--- a/runner/src/server/services/addressLookupService.ts
+++ b/runner/src/server/services/addressLookupService.ts
@@ -60,12 +60,15 @@ export class AddressLookupService {
     }
 
     const jsonRes = await res.json();
+
     return {
-      addresses: jsonRes.matchedAddresses.map((item: any): Address => ({
-        address: item.addressString,
-        postcode: item.postcode,
-        uprn: item.uprn,
-      }))
+      addresses: jsonRes.matchedAddresses.map(
+        (item: any): Address => ({
+          address: item.addressString,
+          postcode: item.postcode,
+          uprn: item.uprn,
+        })
+      ),
     };
   }
 }

--- a/runner/test/cases/server/plugins/engine/helpers.test.ts
+++ b/runner/test/cases/server/plugins/engine/helpers.test.ts
@@ -6,11 +6,16 @@ import {
   redirectUrl,
   nonRelativeRedirectUrl,
   getValidStateFromQueryParameters,
+  getReturnUrl,
+  getBackLink,
 } from "src/server/plugins/engine/helpers";
 import sinon from "sinon";
 import Joi from "joi";
+
 const lab = Lab.script();
+
 exports.lab = lab;
+
 const { expect } = Code;
 const { beforeEach, describe, suite, test } = lab;
 
@@ -92,6 +97,42 @@ suite("Helpers", () => {
 
       expect(h.redirect.callCount).to.equal(1);
       expect(h.redirect.firstCall.args[0]).to.equal(`${nextUrl}`);
+      expect(returned).to.equal(returnValue);
+    });
+
+    test("Should redirect to next url (not returnUrl) when honourReturnUrl is false, carrying returnUrl forward for a later step to honour", () => {
+      const returnUrl = "/my-return-url";
+      const request = {
+        query: {
+          returnUrl: returnUrl,
+        },
+      };
+      const nextUrl = "badgers/monkeys";
+      const returned = proceed(request, h, nextUrl, false);
+
+      expect(h.redirect.callCount).to.equal(1);
+      expect(h.redirect.firstCall.args[0]).to.equal(
+        `${nextUrl}?returnUrl=%2Fmy-return-url`
+      );
+      expect(returned).to.equal(returnValue);
+    });
+
+    test("Should not redirect to a protocol-relative returnUrl (open redirect)", () => {
+      const request = {
+        query: {
+          returnUrl: "//evil.example.com",
+        },
+      };
+      const nextUrl = "badgers/monkeys";
+      const returned = proceed(request, h, nextUrl);
+
+      expect(h.redirect.callCount).to.equal(1);
+      // Not honoured as an immediate redirect target - falls through to
+      // redirectTo, which carries the (still-unsafe) value forward as a
+      // query param rather than ever passing it to h.redirect directly.
+      expect(h.redirect.firstCall.args[0]).to.equal(
+        `${nextUrl}?returnUrl=%2F%2Fevil.example.com`
+      );
       expect(returned).to.equal(returnValue);
     });
   });
@@ -388,6 +429,42 @@ suite("Helpers", () => {
         Object.keys(getValidStateFromQueryParameters(prePopFields, query))
           .length
       ).to.equal(0);
+    });
+  });
+
+  describe("getReturnUrl", () => {
+    test("Should return the returnUrl when it is present and internal", () => {
+      const request = { query: { returnUrl: "/summary" } };
+      expect(getReturnUrl(request)).to.equal("/summary");
+    });
+
+    test("Should return undefined when returnUrl is missing", () => {
+      const request = { query: {} };
+      expect(getReturnUrl(request)).to.equal(undefined);
+    });
+
+    test("Should return undefined when returnUrl does not start with /", () => {
+      const request = { query: { returnUrl: "https://evil.example.com" } };
+      expect(getReturnUrl(request)).to.equal(undefined);
+    });
+
+    test("Should return undefined when returnUrl is protocol-relative (open redirect)", () => {
+      const request = { query: { returnUrl: "//evil.example.com" } };
+      expect(getReturnUrl(request)).to.equal(undefined);
+    });
+  });
+
+  describe("getBackLink", () => {
+    test("Should use returnUrl when it is present and internal", () => {
+      const request = { query: { returnUrl: "/summary" } };
+      expect(getBackLink(request, ["/a", "/b"], "/fallback")).to.equal(
+        "/summary"
+      );
+    });
+
+    test("Should fall back to progress history when returnUrl is protocol-relative (open redirect)", () => {
+      const request = { query: { returnUrl: "//evil.example.com" } };
+      expect(getBackLink(request, ["/a", "/b"], "/fallback")).to.equal("/a");
     });
   });
 });


### PR DESCRIPTION
Fixes issues when navigating from the summary page using the change links.

Also allows multi-stage changes. Previously it would navigate back to the summary page on continue but in our form setting an address requires at least two stages (search an address & confirm its the correct address)