### PR TITLE
rps-1394 Delivery Details

### DIFF
--- a/runner/src/server/forms/order-a-radon-home-test-kit.json
+++ b/runner/src/server/forms/order-a-radon-home-test-kit.json
@@ -627,7 +627,7 @@
         "title": "What address do you want your radon gas test results to be delivered to?",
         "components": [
           {
-            "name": "Address Line 1",
+            "name": "AddressLine1",
             "options": {
               "customValidationMessages":{
                 "string.empty": "Enter address line 1, typically the building and street"
@@ -638,7 +638,7 @@
             "title": "Address Line 1"
           },
           {
-            "name": "Address Line 2",
+            "name": "AddressLine2",
             "options": {
               "required": false,
               "exposeToContext": true
@@ -647,7 +647,7 @@
             "title": "Address Line 2"
           },
           {
-            "name": "Town or city",
+            "name": "TownOrCity",
             "options": {
               "customValidationMessages":{
                 "string.empty": "Enter town or city"
@@ -667,7 +667,7 @@
             "title": "County"
           },
           {
-            "name": "postcodeLookup",
+            "name": "Postcode",
             "options": {
               "customValidationMessages": {
                 "string.empty": "Enter postcode",
@@ -777,7 +777,7 @@
           "title": "County"
         },
         {
-          "name": "postcodeLookup",
+          "name": "KitPostcode",
           "options": {
             "customValidationMessages": {
               "string.empty": "Enter postcode",
@@ -799,7 +799,44 @@
           "title": "Postcode"
         }
       ],
-      "next": [{"path": "/gas-test-kit-check-your-answers"}]
+      "next": [
+        {"path": "/gas-test-kit-delivery-address-same-as-results", "condition": "incorrectKitAddressIncorrectResultsAddress"},
+        {"path": "/gas-test-kit-check-your-answers"}
+    ]
+    },
+    {
+      "path": "/gas-test-kit-delivery-address-same-as-results",
+      "title": "Delivery Details",
+      "components":[
+        {
+          "name": "deliveryAddress",
+          "options": {},
+          "type": "Html",
+          "content": "<div class=\"govuk-inset-text\">{{ KitAddressLine1 }}</br>{% if KitAddressLine2 %} {{ KitAddressLine2 }}</br>{% endif %}{{ KitTown }}<br>{% if KitCounty %}{{ KitCounty }}</br>{% endif %}{{ KitPostcode }}</div>",
+          "schema": {}
+        },
+        {
+          "name": "ResultsDeliveryQuestion",
+          "options": {},
+          "type": "Para",
+          "content": "<p class=\"govuk-body-m\"><h2 class=\"govuk-heading-m\">Is this the address you want your radon gas test results delivered to?</h2></p>"
+        },
+        {
+          "name": "deliveryResultsConfirmation",
+          "options": {
+            "customValidationMessages": {
+              "any.required": "Select yes if this is the address you want your radon gas test results delivered to"
+            }
+          },
+          "type": "YesNoField",
+          "title": "Is this the address you want your radon gas test results delivered to?",
+          "schema": {}
+        }
+      ],
+      "next": [
+        {"path":"/who-is-the-recipient-of-radon-gas-test-results", "condition": "DeliveryDetailsIncorrectResultsAddress"},
+        {"path": "/gas-test-kit-check-your-answers"}
+      ]
     },
     {
       "path": "/gas-test-kit-check-your-answers",
@@ -823,7 +860,6 @@
           "type": "Para",
           "content": "<table class=\"govuk-table\"><caption class=\"govuk-table__caption govuk-table__caption--m\">Contact Information</caption><tbody class=\"govuk-table__body\"><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Title</th><td class=\"govuk-table__cell\">{{ Title }}</td><td class=\"govuk-table__cell\"><a href=\"/gas-test-kit/enter-details\" \"target\"=\"_blank\">Change</a></td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Initials</th><td class=\"govuk-table__cell\">{{ Initials }}</td><td class=\"govuk-table__cell\"><a href=\"/gas-test-kit/enter-details\" \"target\"=\"_blank\">Change</a></td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Last name</th><td class=\"govuk-table__cell\">{{ LastName }}</td><td class=\"govuk-table__cell\"><a href=\"/gas-test-kit/enter-details\" \"target\"=\"_blank\">Change</a></td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Email</th><td class=\"govuk-table__cell\">{{ EmailAddress }}</td><td class=\"govuk-table__cell\"><a href=\"/gas-test-kit/enter-details\" \"target\"=\"_blank\">Change</a></td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Property address</th><td class=\"govuk-table__cell\">{{ PropertyAddress }}</td><td class=\"govuk-table__cell\"><a href=\"google.com\" \"target\"=\"_blank\">Change</a></td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Delivery recipient</th><td class=\"govuk-table__cell\">{{ DeliveryRecipient }}</td><td class=\"govuk-table__cell\"><a href=\"/gas-test-kit/enter-details\" \"target\"=\"_blank\">Change</a></td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Delivery address</th><td class=\"govuk-table__cell\">{{ DeliveryAddress }}</td><td class=\"govuk-table__cell\"><a href=\"google.com\" \"target\"=\"_blank\">Change</a></td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Results recipient</th><td class=\"govuk-table__cell\">{{ ResultsRecipient }}</td><td class=\"govuk-table__cell\"><a href=\"google.com\" \"target\"=\"_blank\">Change</a></td></tr><tr class=\"govuk-table__row\"><th scope=\"row\" class=\"govuk-table__header\">Results address</th><td class=\"govuk-table__cell\">{{ ResultsAddress }}</td><td class=\"govuk-table__cell\"><a href=\"google.com\" \"target\"=\"_blank\">Change</a></td></tr></tbody></table>"
         },
-
         {
           "name": "checkbox",
           "type": "CheckboxesField",
@@ -1143,7 +1179,54 @@
           }
         ]
       }
+    },
+    {
+      "displayName": "incorrectKitAddressIncorrectResultsAddress",
+      "name": "incorrectKitAddressIncorrectResultsAddress",
+      "value": {
+        "name": "incorrectKitAddressIncorrectResultsAddress",
+        "conditions": [
+          {
+            "field": {
+              "name": "deliveryAddressConfirmation",
+              "type": "YesNoField",
+              "display": "Is this the address you want the kit delivered to?"
+            },
+            "operator": "is",
+            "value": { "type": "Value", "value": "false", "display": "false" }
+          },
+          {
+            "coordinator": "and",
+            "field": {
+              "name": "resultsAddressConfirmation",
+              "type": "YesNoField",
+              "display": "Is this the address you want your radon gas test results to?"
+            },
+            "operator": "is",
+            "value": { "type": "Value", "value": "false", "display": "false" }
+          }
+        ]
+      }
+    },{
+      "displayName": "DeliveryDetailsIncorrectResultsAddress",
+      "name": "DeliveryDetailsIncorrectResultsAddress",
+      "value": {
+        "name": "DeliveryDetailsIncorrectResultsAddress",
+        "conditions": [
+          {
+            "field": {
+              "name": "deliveryResultsConfirmation",
+              "type": "YesNoField",
+              "display": "Is this the address you want the kit delivered to?"
+            },
+            "operator": "is",
+            "value": { "type": "Value", "value": "false", "display": "false" }
+          }
+        ]
+      }
     }
+
+    
   ],
   "fees": [],
   "outputs": [

--- a/runner/src/server/forms/order-a-radon-home-test-kit.json
+++ b/runner/src/server/forms/order-a-radon-home-test-kit.json
@@ -463,7 +463,7 @@
           "name": "Title",
           "options": {
             "exposeToContext": true,
-            "customValidationMessages": {
+            "customValidationMessages":{
               "string.empty": "Enter your Title"
             }
           },
@@ -474,7 +474,7 @@
         {
           "name": "Initials",
           "options": {
-            "customValidationMessages": {
+            "customValidationMessages":{
               "string.empty": "Enter your Initials"
             },
             "exposeToContext": true
@@ -537,7 +537,7 @@
         },
         {
           "name": "deliveryAddressConfirmation",
-          "options": { "hideTitle": true },
+          "options": {"hideTitle": true},
           "type": "YesNoField",
           "title": "Is this the address you want the kit delivered to?"
         },
@@ -561,7 +561,7 @@
         },
         {
           "name": "resultsAddressConfirmation",
-          "options": { "hideTitle": true },
+          "options": {"hideTitle": true},
           "type": "YesNoField",
           "title": "Is this the address you want your radon gas test results to?"
         },
@@ -595,7 +595,7 @@
           "name": "ResultsTitle",
           "options": {
             "exposeToContext": true,
-            "customValidationMessages": {
+            "customValidationMessages":{
               "string.empty": "Enter the title of the recipient of the radon gas test results"
             }
           },
@@ -606,7 +606,7 @@
         {
           "name": "ResultsInitials",
           "options": {
-            "customValidationMessages": {
+            "customValidationMessages":{
               "string.empty": "Enter the initials of the recipient of the radon gas test results"
             },
             "exposeToContext": true
@@ -617,16 +617,16 @@
         {
           "name": "ResultsLastName",
           "options": {
-            "customValidationMessages": {
+            "customValidationMessages":{
               "string.empty": "Enter the last name of the recipient of the radon gas test results"
             },
-            "exposeToContext": true
+            "exposeToContext": true 
           },
           "type": "TextField",
           "title": "Last Name"
         }
       ],
-      "next": [{ "path": "/gas-test-kit-enter-results-address-manually" }]
+      "next": [{"path": "/gas-test-kit-enter-results-address-manually"}]
     },
     {
         "path": "/gas-test-kit-enter-results-address-manually",
@@ -640,7 +640,8 @@
               },
               "exposeToContext": true
             },
-            "exposeToContext": true
+            "type": "TextField",
+            "title": "Address Line 1"
           },
           {
             "name": "AddressLine2",
@@ -659,16 +660,17 @@
               },
               "exposeToContext": true
             },
-            "exposeToContext": true
+            "type": "TextField",
+            "title": "Town or city"
           },
-          "type": "TextField",
-          "title": "Town or city"
-        },
-        {
-          "name": "County",
-          "options": {
-            "required": false,
-            "exposeToContext": true
+          {
+            "name": "County",
+            "options": {
+              "required": false,
+              "exposeToContext": true
+            },
+            "type": "TextField",
+            "title": "County"
           },
           {
             "name": "Postcode",
@@ -707,63 +709,34 @@
                 "string.empty": "Enter the title of the recipient of the kit"
               }
             },
-            "autocomplete": "postal-code",
-            "exposeToContext": true,
-            "format": {
-              "trim": true,
-              "case": "upper"
-            }
+            "type": "TextField",
+            "title": "Title",
+            "hint": "e.g. Mr, Mrs, Dr"
           },
-          "schema": {
-            "max": 10,
-            "regex": "^[\\s]*[A-z]{1,2}[0-9][A-z0-9]?[\\s]*[0-9]{1,2}[ABD-hJLNP-uW-z]{2}[\\s]*$"
-          },
-          "type": "TextField",
-          "title": "Postcode"
-        }
-      ],
-      "next": [{ "path": "/gas-test-kit-check-your-answers" }]
-    },
-    {
-      "path": "/who-is-the-recipient-of-the-kit",
-      "title": "Who is the recipient of the kit?",
-      "components": [
-        {
-          "name": "KitTitle",
-          "options": {
-            "exposeToContext": true,
-            "customValidationMessages": {
-              "string.empty": "Enter the title of the recipient of the kit"
-            }
-          },
-          "type": "TextField",
-          "title": "Title",
-          "hint": "e.g. Mr, Mrs, Dr"
-        },
-        {
-          "name": "KitInitials",
-          "options": {
-            "customValidationMessages": {
-              "string.empty": "Enter the initials of the recipient of the kit"
+          {
+            "name": "KitInitials",
+            "options": {
+              "customValidationMessages":{
+                "string.empty": "Enter the initials of the recipient of the kit"
+              },
+              "exposeToContext": true
             },
-            "exposeToContext": true
+            "type": "TextField",
+            "title": "Initials"
           },
-          "type": "TextField",
-          "title": "Initials"
-        },
-        {
-          "name": "KitLastName",
-          "options": {
-            "customValidationMessages": {
-              "string.empty": "Enter the last name of the recipient of the kit"
+          {
+            "name": "KitLastName",
+            "options": {
+              "customValidationMessages":{
+                "string.empty": "Enter the last name of the recipient of the kit"
+              },
+              "exposeToContext": true 
             },
-            "exposeToContext": true
-          },
-          "type": "TextField",
-          "title": "Last Name"
-        }
-      ],
-      "next": [{ "path": "/gas-test-kit-enter-delivery-address-manually" }]
+            "type": "TextField",
+            "title": "Last Name"
+          }
+        ],
+      "next": [{"path": "/gas-test-kit-enter-delivery-address-manually"}]
     },
     {
       "path": "/gas-test-kit-enter-delivery-address-manually",
@@ -772,7 +745,7 @@
         {
           "name": "KitAddressLine1",
           "options": {
-            "customValidationMessages": {
+            "customValidationMessages":{
               "string.empty": "Enter address line 1, typically the building and street"
             },
             "exposeToContext": true
@@ -792,7 +765,7 @@
         {
           "name": "KitTown",
           "options": {
-            "customValidationMessages": {
+            "customValidationMessages":{
               "string.empty": "Enter town or city"
             },
             "exposeToContext": true
@@ -904,10 +877,11 @@
             "customValidationMessages": {
               "any.required": "<p class=\"govuk-body-m\">You must accept the <a href=\"https://www.ukhsa-protectionservices.org.uk/tc/privacy-policy\" target=\"_blank\">Privacy Policy</a> and <a href=\"https://www.ukhsa-protectionservices.org.uk/tc/terms-conditions\" target=\"_blank\">Terms and Conditions</a> before continuing</p>"
             }
+            
           }
         }
       ],
-      "next": [{ "path": "/payment" }]
+      "next": [{"path": "/payment"}]
     },
     {
       "title": "Summary",


### PR DESCRIPTION
> [!NOTE]
> This template is designed to help both contributors and maintainers. It is a checklist to ensure all necessary
> information is provided, and prompts contributors on any contribution guidelines they have missed.
>
> Do not remove sections.
> They are important for the review process and help maintainers ensure quality and good documentation across the
> project.
>
> Some checkboxes will not apply to every change, so feel free to leave them unchecked if they are not relevant.

# Description


## Changes

- Delivery Details page
- Retooled flow

## Type of change

What is the type of change you are making?

- [ ] Chore or documentation (non-breaking change that does not add functionality)
- [ ] ADR (Architectural Decision Record, non-breaking change that documents or proposes a decision)
- [ ] Refactor (non-breaking change that improves code quality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### PR title

PR titles should be prefixed with the type of change you are making, based on the [README.md#versioning](https://github.com/XGovFormBuilder/digital-form-builder?tab=readme-ov-file#versioning).
This is so that when performing a squash merge, the PR title is automatically used as the commit message.

Have you updated the PR title to match the type of change you are making?

- [ ] Yes
- [ ] No, I need help or guidance

# Testing

<!--
Several departments use XGovFormBuilder in production.
Automated tests help ensure that changes do not break existing functionality for another department.

Maintainers are sympathetic to the time constraints of government departments, but please try to be good citizens and add tests when possible.
-->

## Automated tests

Have you added automated tests?

- [ ] Yes, unit or integration tests
- [ ] Yes, end-to-end (cypress) tests
- [ ] No, tests are not required for this change
- [ ] No, I need help or guidance
- [ ] No (explain why tests are not required or can't be added at this time)

## Manual tests

Have you manually tested your changes?

- [ ] Yes
- [ ] No, manual tests are not required or sufficiently covered by automated tests

Have you attached an example form JSON or snippet for the reviewer in this PR?

- [ ] Yes
- [ ] No, any existing form can be used
- [ ] No, it is not required or not applicable

### Steps to test

<!--
Only fill out this section if you answered "Yes" to manually testing your changes.

In this section
- describe the tests that you ran to verify your changes
- provide instructions and a form JSON or snippet so we can reproduce the test if necessary

If uploading a form JSON, use the "attach files" feature in GitHub PR.
-->

1. Step 1
2. Step 2

# Documentation

Have you updated the documentation?

- [ ] Yes, I have updated [./docs](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs) for this change since additional explanation or steps to use/configure the feature is required
- [ ] Yes, I have added or updated an [ADR](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs/adr) for this change since it is large, complex, or has significant architectural implications
- [ ] Yes, I have added inline comments for hard-to-understand areas
- [ ] No, I am not sure if documentation is required
- [ ] No, documentation is not required for this change

# Discussion

> [!WARNING]
>
> Large or complex changes may require discussion with the maintainers before they can be merged. If it has not yet been discussed, it may delay the review process

Have you discussed this change with the maintainers?

- [ ] Yes, I have discussed this change with the maintainers on slack, email or via GitHub issues
- [ ] Yes, this change is an ADR to help kick-off discussion
- [ ] No, this change is small and does not require discussion
- [ ] No, I am not sure if one is required
