### PR TITLE
Spike redirection logic 

### DIFF
--- a/runner/src/server/forms/spike-form-redirect.json
+++ b/runner/src/server/forms/spike-form-redirect.json
@@ -1,0 +1,72 @@
+{
+  "metadata": {},
+  "startPage": "/start",
+  "name": "Spike Form",
+  "skipSummary": true,
+  "magicLinkConfig": "spike-form-redirect",
+  "toggleRedirect": "spike-form",
+  "pages": [
+    {
+      "path": "/start",
+      "title": "Spike Form 2 - We redirected!! But can we make it back.. WITH your data!? 😱",
+      "components": [
+        {
+          "name": "FeedbackPara",
+          "options": {},
+          "type": "Para",
+          "content": "<label class='govuk-label govuk-label--s'>Can we send your data between services?</label>"
+        },
+        {
+          "name": "TextInput",
+          "options": {
+            "required": true,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter a second input to see if we can pass it between services"
+            }
+          },
+          "title": "Thoughts on .. cats?",
+          "type": "TextField"
+        }
+      ],
+      "next": [
+        {
+          "path": "/submit"
+        }
+      ]
+    },
+    {
+      "path": "/submit",
+      "controller": "CrossFormSubmitController"
+    }
+  ],
+  "lists": [],
+  "outputs": [
+    {
+      "name": "SpikeFormRedirect",
+      "title": "Spike Form Redirect",
+      "type": "email",
+      "outputConfiguration": {
+        "apiKey": "${notifyApiKey}",
+        "emailAddress": "${emailAddress}",
+        "notifyTemplateId": "83d1c036-dfeb-4d5b-b4e3-e8125810c663"
+      }
+    }
+  ],
+  "sections": [],
+  "conditions": [],
+  "phaseBanner": {
+    "phase": "beta"
+  },
+  "feedback": {
+    "feedbackForm": true,
+    "url": "/feedback"
+  },
+  "specialPages": {
+    "confirmationPage": {
+      "customText": {
+        "nextSteps": "<h1 class='govuk-heading-l'>Thank you for completing this survey</h1><p class='govuk-body'>You can now close this page.</p>",
+        "hidePanel": true
+      }
+    }
+  }
+}

--- a/runner/src/server/forms/spike-form.json
+++ b/runner/src/server/forms/spike-form.json
@@ -39,14 +39,19 @@
       "next": []
     },
     {
+      "path": "/return",
+      "controller": "CrossFormReturnController",
+      "next": []
+    },
+    {
       "title": "You've.. you've returned! 🤩",
-      "path": "/redirect-check-your-details",
+      "path": "/check-your-details",
       "components": [
         {
           "name": "ReturnMessage",
           "options": {},
           "type": "Para",
-          "content": "<label class='govuk-label govuk-label--s'>Check the logs!</label>"
+          "content": "<label class='govuk-label govuk-label--s'>Check the logs to see if the details are correct!</label>"
         }
       ],
       "next": [{ "path": "/summary" }]

--- a/runner/src/server/forms/spike-form.json
+++ b/runner/src/server/forms/spike-form.json
@@ -1,0 +1,89 @@
+{
+  "metadata": {},
+  "startPage": "/start",
+  "name": "Spike Form",
+  "skipSummary": true,
+  "toggleRedirect": "spike-form-redirect",
+  "pages": [
+    {
+      "path": "/start",
+      "title": "Spike Form - Can we do it?! 🤔",
+      "components": [
+        {
+          "name": "FeedbackPara",
+          "options": {},
+          "type": "Para",
+          "content": "<label class='govuk-label govuk-label--s'>Can we send your data between services?</label>"
+        },
+        {
+          "name": "TextInput",
+          "options": {
+            "required": true,
+            "customValidationMessages": {
+              "string.pattern.base": "Enter an input to see if we can pass it between services"
+            }
+          },
+          "title": "Thoughts on dogs?",
+          "type": "TextField"
+        }
+      ],
+      "next": [
+        {
+          "path": "/redirect"
+        }
+      ]
+    },
+    {
+      "path": "/redirect",
+      "controller": "CrossFormRedirectController",
+      "next": []
+    },
+    {
+      "title": "You've.. you've returned! 🤩",
+      "path": "/redirect-check-your-details",
+      "components": [
+        {
+          "name": "ReturnMessage",
+          "options": {},
+          "type": "Para",
+          "content": "<label class='govuk-label govuk-label--s'>Check the logs!</label>"
+        }
+      ],
+      "next": [{ "path": "/summary" }]
+    },
+    {
+      "path": "/summary",
+      "controller": "./pages/summary.js"
+    }
+  ],
+  "lists": [],
+  "outputs": [
+    {
+      "name": "SpikeForm",
+      "title": "Spike Form",
+      "type": "email",
+      "outputConfiguration": {
+        "apiKey": "${notifyApiKey}",
+        "emailAddress": "${emailAddress}",
+        "notifyTemplateId": "83d1c036-dfeb-4d5b-b4e3-e8125810c663"
+      }
+    }
+  ],
+  "sections": [],
+  "conditions": [],
+  "phaseBanner": {
+    "phase": "beta"
+  },
+  "feedback": {
+    "feedbackForm": true,
+    "url": "/feedback"
+  },
+  "specialPages": {
+    "confirmationPage": {
+      "customText": {
+        "nextSteps": "<h1 class='govuk-heading-l'>Thank you for completing this survey</h1><p class='govuk-body'>You can now close this page.</p>",
+        "hidePanel": true
+      }
+    }
+  }
+}

--- a/runner/src/server/index.ts
+++ b/runner/src/server/index.ts
@@ -37,6 +37,7 @@ import {
   FormSecurityService,
   SecureFormSubmissionService,
   getSecureFormSubmissionServiceInstance,
+  CrossFormCacheService,
 } from "./services";
 import { HapiRequest, HapiResponseToolkit, RouteConfig } from "./types";
 import getRequestInfo from "./utils/getRequestInfo";
@@ -121,6 +122,7 @@ async function createServer(routeConfig: RouteConfig) {
     AddressService,
     ExitService,
     FormSecurityService,
+    CrossFormCacheService, // add new CrossFormCacheService to the list of registered services
   ]);
   if (!config.documentUploadApiUrl) {
     server.registerService([

--- a/runner/src/server/plugins/engine/pageControllers/CrossFormRedirectController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/CrossFormRedirectController.ts
@@ -1,0 +1,24 @@
+import { PageController } from "server/plugins/engine/pageControllers/PageController";
+import { HapiRequest, HapiResponseToolkit } from "server/types";
+
+export class CrossFormRedirectController extends PageController {
+  makeGetRouteHandler() {
+    return async (request: HapiRequest, h: HapiResponseToolkit) => {
+      const id = request.params?.id;
+      const forms = request.server?.app?.forms;
+      const model = id && forms?.[id];
+
+      // You should define your own magicLinkConfig in your (main) form config
+      const crossFormRedirectConfig =
+        model?.def?.magicLinkConfig ?? "spike-form-redirect";
+
+      const { crossFormCacheService } = request.services([]);
+      /* In order to support resume, we need to store the form id */
+      await crossFormCacheService.saveFormIdBeforeCrossFormRedirectToAllowResume(
+        request
+      );
+
+      return h.redirect(`/${crossFormRedirectConfig}/start`).code(302);
+    };
+  }
+}

--- a/runner/src/server/plugins/engine/pageControllers/CrossFormReturnController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/CrossFormReturnController.ts
@@ -10,7 +10,7 @@ export class CrossFormReturnController extends PageController {
       console.log("CROSS FORM RETURN CONTROLLER HIT");
       const previousState = await request
         .services([])
-        .cacheService.getState(request);
+        .cacheService.getState(request); // Currently {} 😱
       console.log("Previous state", previousState);
       return this.makePostRouteHandler()(request, h);
     };
@@ -20,7 +20,7 @@ export class CrossFormReturnController extends PageController {
     return async (request: HapiRequest, h: HapiResponseToolkit) => {
       console.log("CROSS FORM RETURN POST HIT");
       const transferId = request.query?.transferId;
-      console.log("transferId", transferId);
+      console.log("transferId", transferId); // this is successfully being passed ✅
       const { crossFormCacheService } = request.services([]);
       await crossFormCacheService.restoreInformationFromCrossFormResume(
         request,
@@ -28,7 +28,7 @@ export class CrossFormReturnController extends PageController {
       );
       console.log(
         "Merged state",
-        await request.services([]).cacheService.getState(request)
+        await request.services([]).cacheService.getState(request) // Currently {} 😱
       );
       return h.redirect(`/${this.model.basePath}/check-your-details`).code(302);
     };

--- a/runner/src/server/plugins/engine/pageControllers/CrossFormReturnController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/CrossFormReturnController.ts
@@ -1,0 +1,36 @@
+import { HapiRequest, HapiResponseToolkit } from "src/server/types";
+import { PageController } from "./PageController";
+
+export class CrossFormReturnController extends PageController {
+  constructor(model, pageDef) {
+    super(model, pageDef);
+  }
+  makeGetRouteHandler() {
+    return async (request: HapiRequest, h: HapiResponseToolkit) => {
+      console.log("CROSS FORM RETURN CONTROLLER HIT");
+      const previousState = await request
+        .services([])
+        .cacheService.getState(request);
+      console.log("Previous state", previousState);
+      return this.makePostRouteHandler()(request, h);
+    };
+  }
+
+  makePostRouteHandler() {
+    return async (request: HapiRequest, h: HapiResponseToolkit) => {
+      console.log("CROSS FORM RETURN POST HIT");
+      const transferId = request.query?.transferId;
+      console.log("transferId", transferId);
+      const { crossFormCacheService } = request.services([]);
+      await crossFormCacheService.restoreInformationFromCrossFormResume(
+        request,
+        transferId
+      );
+      console.log(
+        "Merged state",
+        await request.services([]).cacheService.getState(request)
+      );
+      return h.redirect(`/${this.model.basePath}/check-your-details`).code(302);
+    };
+  }
+}

--- a/runner/src/server/plugins/engine/pageControllers/CrossFormSubmitController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/CrossFormSubmitController.ts
@@ -4,11 +4,8 @@ import { PageController } from "./PageController";
 import { v4 as uuidv4 } from "uuid";
 
 export class CrossFormSubmitController extends PageController {
-  RETRY_TIMEOUT_SECONDS: number;
-
   constructor(model, pageDef) {
     super(model, pageDef);
-    this.RETRY_TIMEOUT_SECONDS = this.model.def.retryTimeoutSeconds ?? 300;
   }
 
   makeGetRouteHandler() {
@@ -23,8 +20,6 @@ export class CrossFormSubmitController extends PageController {
       const { cacheService, crossFormCacheService } = request.services([]);
       const state = await cacheService.getState(request);
 
-      console.log("Current form 2 state:", state);
-
       const transferId = uuidv4();
 
       await crossFormCacheService.saveInformationToAllowCrossFormResume(
@@ -37,7 +32,7 @@ export class CrossFormSubmitController extends PageController {
       return redirectTo(
         request,
         h,
-        `/${this.model.values.toggleRedirect}/redirect-check-your-details?transferId=${transferId}`
+        `/${this.model.values.toggleRedirect}/return?transferId=${transferId}`
       );
     };
   }

--- a/runner/src/server/plugins/engine/pageControllers/CrossFormSubmitController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/CrossFormSubmitController.ts
@@ -1,0 +1,44 @@
+import { HapiRequest, HapiResponseToolkit } from "src/server/types";
+import { redirectTo } from "../helpers";
+import { PageController } from "./PageController";
+import { v4 as uuidv4 } from "uuid";
+
+export class CrossFormSubmitController extends PageController {
+  RETRY_TIMEOUT_SECONDS: number;
+
+  constructor(model, pageDef) {
+    super(model, pageDef);
+    this.RETRY_TIMEOUT_SECONDS = this.model.def.retryTimeoutSeconds ?? 300;
+  }
+
+  makeGetRouteHandler() {
+    return async (request: HapiRequest, h: HapiResponseToolkit) => {
+      return this.makePostRouteHandler()(request, h);
+    };
+  }
+
+  makePostRouteHandler() {
+    return async (request: HapiRequest, h: HapiResponseToolkit) => {
+      this.request = request; // Store request for use in getter methods
+      const { cacheService, crossFormCacheService } = request.services([]);
+      const state = await cacheService.getState(request);
+
+      console.log("Current form 2 state:", state);
+
+      const transferId = uuidv4();
+
+      await crossFormCacheService.saveInformationToAllowCrossFormResume(
+        request,
+        transferId
+      );
+
+      console.log("Current form 2 state after saveInfo:", state);
+
+      return redirectTo(
+        request,
+        h,
+        `/${this.model.values.toggleRedirect}/redirect-check-your-details?transferId=${transferId}`
+      );
+    };
+  }
+}

--- a/runner/src/server/plugins/engine/pageControllers/SpikeFormRedirectController.ts
+++ b/runner/src/server/plugins/engine/pageControllers/SpikeFormRedirectController.ts
@@ -1,0 +1,25 @@
+import { PageController } from "server/plugins/engine/pageControllers/PageController";
+import { HapiRequest, HapiResponseToolkit } from "server/types";
+
+export class MagicLinkRedirectController extends PageController {
+  makeGetRouteHandler() {
+    return async (request: HapiRequest, h: HapiResponseToolkit) => {
+      const id = request.params?.id;
+      const forms = request.server?.app?.forms;
+      const model = id && forms?.[id];
+
+      // Fallback to the default Magic Link config used by CareOBRA
+      // WARNING: This has hardcoded values
+      // You should define your own magicLinkConfig in your (main) form config
+      const magicLinkConfig = model?.def?.magicLinkConfig ?? "magic-link";
+
+      const { magicLinkCacheService } = request.services([]);
+      /* In order to support resume, we need to store the form id */
+      await magicLinkCacheService.saveFormIdBeforeMagicLinkRedirectToAllowResume(
+        request
+      );
+
+      return h.redirect(`/${magicLinkConfig}/start`).code(302);
+    };
+  }
+}

--- a/runner/src/server/plugins/engine/pageControllers/helpers.ts
+++ b/runner/src/server/plugins/engine/pageControllers/helpers.ts
@@ -3,6 +3,8 @@ import { camelCase, upperFirst } from "lodash";
 import { DobPageController } from "./DobPageController";
 import { HomePageController } from "./HomePageController";
 import { PageController } from "./PageController";
+import { CrossFormRedirectController } from "./CrossFormRedirectController";
+import { CrossFormSubmitController } from "./CrossFormSubmitController";
 import { StartDatePageController } from "./StartDatePageController";
 import { StartPageController } from "./StartPageController";
 import { SummaryPageController } from "./SummaryPageController";
@@ -43,6 +45,8 @@ const PageControllers = {
   CustomSummaryPageController,
   DateComparisonPageController,
   MagicLinkRedirectController,
+  CrossFormRedirectController, // Add the CrossFormRedirectController here
+  CrossFormSubmitController, // Add the CrossFormSubmitController here
 };
 
 export const controllerNameFromPath = (filePath: string) => {

--- a/runner/src/server/plugins/engine/pageControllers/helpers.ts
+++ b/runner/src/server/plugins/engine/pageControllers/helpers.ts
@@ -3,8 +3,6 @@ import { camelCase, upperFirst } from "lodash";
 import { DobPageController } from "./DobPageController";
 import { HomePageController } from "./HomePageController";
 import { PageController } from "./PageController";
-import { CrossFormRedirectController } from "./CrossFormRedirectController";
-import { CrossFormSubmitController } from "./CrossFormSubmitController";
 import { StartDatePageController } from "./StartDatePageController";
 import { StartPageController } from "./StartPageController";
 import { SummaryPageController } from "./SummaryPageController";
@@ -23,6 +21,9 @@ import { MagicLinkStartPageController } from "./MagicLinkStartPageController";
 import { CustomSummaryPageController } from "./CustomSummaryPageController";
 import { DateComparisonPageController } from "./DateComparisonPageController";
 import { MagicLinkRedirectController } from "./MagicLinkRedirectController";
+import { CrossFormReturnController } from "./CrossFormReturnController";
+import { CrossFormRedirectController } from "./CrossFormRedirectController";
+import { CrossFormSubmitController } from "./CrossFormSubmitController";
 
 const PageControllers = {
   DobPageController,
@@ -47,6 +48,7 @@ const PageControllers = {
   MagicLinkRedirectController,
   CrossFormRedirectController, // Add the CrossFormRedirectController here
   CrossFormSubmitController, // Add the CrossFormSubmitController here
+  CrossFormReturnController, // Add the CrossFormSubmitController here
 };
 
 export const controllerNameFromPath = (filePath: string) => {

--- a/runner/src/server/plugins/engine/pageControllers/index.ts
+++ b/runner/src/server/plugins/engine/pageControllers/index.ts
@@ -14,3 +14,5 @@ export { MagicLinkStartPageController } from "./MagicLinkStartPageController";
 export { CustomSummaryPageController } from "./CustomSummaryPageController";
 export { DateComparisonPageController } from "./DateComparisonPageController";
 export { MagicLinkRedirectController } from "./MagicLinkRedirectController";
+export { CrossFormRedirectController } from "./CrossFormRedirectController";
+export { CrossFormSubmitController } from "./CrossFormSubmitController";

--- a/runner/src/server/plugins/engine/pageControllers/index.ts
+++ b/runner/src/server/plugins/engine/pageControllers/index.ts
@@ -16,3 +16,4 @@ export { DateComparisonPageController } from "./DateComparisonPageController";
 export { MagicLinkRedirectController } from "./MagicLinkRedirectController";
 export { CrossFormRedirectController } from "./CrossFormRedirectController";
 export { CrossFormSubmitController } from "./CrossFormSubmitController";
+export { CrossFormReturnController } from "./CrossFormReturnController";

--- a/runner/src/server/services/CrossFormCacheService.ts
+++ b/runner/src/server/services/CrossFormCacheService.ts
@@ -20,10 +20,12 @@ export class CrossFormCacheService {
     >;
   }
 
+  // STEP 1
   async saveFormIdBeforeCrossFormRedirectToAllowResume(request: HapiRequest) {
     /* Cross Form Redirect Session Resume Step 1: Save the form id before redirecting to the cross form
        Saves form id by session id, to allow retrieval in the cross form flow 
     */
+    console.log("Here I am in saveFormIdBeforeCrossFormRedirectToAllowResume");
     const sessionId = request.yar.id;
 
     /* Form id being redirected to cross form from, for example "ReportAnOutbreak" */
@@ -44,6 +46,8 @@ export class CrossFormCacheService {
     const key = getFormIdBySessionIdKey(sessionId);
     await this.crossFormIdBySessionCache.set(key, { formId }, this.ttl); // Set the form id in cache with a TTL of 24 hours
   }
+
+  // STEP 2
   async saveInformationToAllowCrossFormResume(
     request: HapiRequest,
     transferId: string
@@ -55,6 +59,12 @@ export class CrossFormCacheService {
     */
     const sessionId = request.yar.id;
     const crossFormFormId = request.params.id as string;
+
+    console.log("Here I am in saveInformationToAllowCrossFormResume");
+    console.log("STEP 2", {
+      sessionId,
+      crossFormFormId,
+    });
 
     if (!sessionId || !crossFormFormId) {
       request.logger.error("Cross Form Redirect: Missing data in step 2", {
@@ -69,6 +79,12 @@ export class CrossFormCacheService {
     const previousFormEntry = await this.crossFormIdBySessionCache.get(
       getFormIdBySessionIdKey(sessionId)
     );
+
+    const key = getFormIdBySessionIdKey(sessionId);
+
+    console.log("STEP 2 KEY", key);
+
+    console.log("STEP 2 LOOKUP RESULT", previousFormEntry);
 
     if (!previousFormEntry) {
       request.logger.error("Cross Form Redirect: Missing data in step 2", {
@@ -90,10 +106,154 @@ export class CrossFormCacheService {
       this.ttl
     );
 
+    const check = await this.crossFormReturnDataByTransferId.get(
+      getReturnDataByTransferId(transferId)
+    );
+    console.log("STEP 2 VERIFY SAVE", check);
+
     // Clean up the temporary form id by session id entry
     await this.crossFormIdBySessionCache.drop(
       getFormIdBySessionIdKey(sessionId)
     );
+  }
+
+  // STEP 3
+  async restoreInformationFromCrossFormResume(
+    request: HapiRequest,
+    transferId: string
+  ) {
+    /* Cross Form Redirect Session Resume Step 3: Restore information when returning from the cross form
+      Retrieve the session id and form id from the cache using the transfer id, to allow repopulation of state in the original form flow
+    */
+    const crossDataRestoreEntry = await this.crossFormReturnDataByTransferId.get(
+      getReturnDataByTransferId(transferId)
+    );
+    if (!crossDataRestoreEntry) {
+      request.logger.error(
+        "Cross Form Redirect: Missing data in step 3 (crossDataRestoreEntry undefined)"
+      );
+      return;
+    }
+    const currentSessionId = request.yar.id;
+    const crossFormFormId = request.params.id as string;
+
+    const {
+      sessionId: previousSessionId,
+      formId: previousFormId,
+    } = crossDataRestoreEntry;
+
+    // Log cache data for poc purposes
+    console.log("RESTORE STEP 3", {
+      previousSessionId,
+      previousFormId,
+      currentSessionId,
+      crossFormFormId,
+      sameSession: previousSessionId === currentSessionId,
+    });
+
+    if (!currentSessionId || !previousSessionId || !previousFormId) {
+      request.logger.error("Cross Form Redirect: Missing data in step 3", {
+        currentSessionId,
+        previousSessionId,
+        previousFormId,
+      });
+      return;
+    }
+
+    // WE ARE IN THE SAME BROWSER, SO THIS MAY BE UNNECESSARY, BUT WE WILL KEEP IT FOR NOW
+    if (currentSessionId === previousSessionId) {
+      /* Continuing in same browser, no need to repopulate previous state */
+      request.logger.info("Same session detected");
+    }
+
+    /* Continuing in different session (different browser / new browser / new instance / tab)
+       Re-instate form states from previous session 
+    */
+    await this.mergeFormStateFromPreviousSession({
+      previousSessionId,
+      currentSessionId,
+      formId: crossFormFormId,
+    });
+
+    const restoredPreviousFormState = await this.getFormState(
+      currentSessionId,
+      previousFormId
+    );
+    // Log cache data for poc purposes
+    console.log(
+      "RESTORED FORM 1 STATE",
+      JSON.stringify(restoredPreviousFormState, null, 2)
+    );
+
+    await this.mergeFormStateFromPreviousSession({
+      previousSessionId,
+      currentSessionId,
+      formId: previousFormId,
+    });
+    const restoredCrossFormState = await this.getFormState(
+      currentSessionId,
+      crossFormFormId
+    );
+    // Log cache data for poc purposes
+    console.log(
+      "RESTORED FORM 2 STATE",
+      JSON.stringify(restoredCrossFormState, null, 2)
+    );
+
+    /* Cleaning up state from previous session */
+    await this.clearFormState(previousSessionId, crossFormFormId);
+    await this.clearFormState(previousSessionId, previousFormId);
+
+    /* Delete Cross Form Lookup Entry */
+    await this.crossFormReturnDataByTransferId.drop(
+      getReturnDataByTransferId(transferId)
+    );
+  }
+
+  private async mergeFormStateFromPreviousSession({
+    previousSessionId,
+    currentSessionId,
+    formId,
+  }: {
+    previousSessionId: string;
+    currentSessionId: string;
+    formId: string;
+  }) {
+    const previousFormState = await this.getFormState(
+      previousSessionId,
+      formId
+    );
+
+    await this.mergeFormState(currentSessionId, formId, previousFormState);
+  }
+
+  private async getFormState(sessionId: string, formId: string) {
+    return await this.cacheService.getState({
+      params: { id: formId },
+      yar: { id: sessionId },
+    });
+  }
+  private async mergeFormState(
+    sessionId: string,
+    formId: string,
+    value: Record<string, any>
+  ) {
+    return await this.cacheService.mergeState(
+      {
+        params: { id: formId },
+        yar: { id: sessionId },
+      },
+      value
+    );
+  }
+
+  private async clearFormState(sessionId: string, formId: string) {
+    if (sessionId && formId) {
+      await this.cacheService.clearState({
+        params: { id: formId },
+        yar: { id: sessionId },
+      });
+    }
   }
 }
 

--- a/runner/src/server/services/CrossFormCacheService.ts
+++ b/runner/src/server/services/CrossFormCacheService.ts
@@ -80,7 +80,7 @@ export class CrossFormCacheService {
       getFormIdBySessionIdKey(sessionId)
     );
 
-    const key = getFormIdBySessionIdKey(sessionId);
+    const key = getFormIdBySessionIdKey(sessionId); // Currently NULL 😱
 
     console.log("STEP 2 KEY", key);
 
@@ -93,7 +93,7 @@ export class CrossFormCacheService {
         previousFormEntry,
       });
 
-      return;
+      return; // Currently returning here because previousFormEntry is NULL 😱
     }
 
     /* Save information required to populate state from previous session */
@@ -126,13 +126,13 @@ export class CrossFormCacheService {
       Retrieve the session id and form id from the cache using the transfer id, to allow repopulation of state in the original form flow
     */
     const crossDataRestoreEntry = await this.crossFormReturnDataByTransferId.get(
-      getReturnDataByTransferId(transferId)
+      getReturnDataByTransferId(transferId) // Currently NULL 😱
     );
     if (!crossDataRestoreEntry) {
       request.logger.error(
         "Cross Form Redirect: Missing data in step 3 (crossDataRestoreEntry undefined)"
       );
-      return;
+      return; // Returning here because crossDataRestoreEntry is NULL 😱
     }
     const currentSessionId = request.yar.id;
     const crossFormFormId = request.params.id as string;

--- a/runner/src/server/services/CrossFormCacheService.ts
+++ b/runner/src/server/services/CrossFormCacheService.ts
@@ -1,0 +1,108 @@
+import { Policy, PolicyOptions } from "@hapi/catbox";
+import { HapiRequest, HapiServer } from "../types";
+import { CacheService } from "./cacheService";
+
+export class CrossFormCacheService {
+  cacheService: CacheService;
+
+  crossFormIdBySessionCache: TypedCache<FormIdBySessionIdRecord>;
+  crossFormReturnDataByTransferId: TypedCache<CrossFormReturnDataByTransferId>;
+  ttl = 1000 * 60 * 60 * 24; // 24 hours
+
+  constructor(server: HapiServer) {
+    const { cacheService } = server.services([]);
+    this.cacheService = cacheService;
+    this.crossFormIdBySessionCache = cacheService.cache as TypedCache<
+      FormIdBySessionIdRecord
+    >;
+    this.crossFormReturnDataByTransferId = cacheService.cache as TypedCache<
+      CrossFormReturnDataByTransferId
+    >;
+  }
+
+  async saveFormIdBeforeCrossFormRedirectToAllowResume(request: HapiRequest) {
+    /* Cross Form Redirect Session Resume Step 1: Save the form id before redirecting to the cross form
+       Saves form id by session id, to allow retrieval in the cross form flow 
+    */
+    const sessionId = request.yar.id;
+
+    /* Form id being redirected to cross form from, for example "ReportAnOutbreak" */
+    const formId = request.params.id as string;
+
+    if (!sessionId || !formId) {
+      request.logger.error("Cross Form Redirect: Missing data in step 1", {
+        sessionId,
+        formId,
+      });
+
+      return;
+    }
+    console.log("CrossFormCacheService: Saving formId for sessionId", {
+      sessionId,
+      formId,
+    });
+    const key = getFormIdBySessionIdKey(sessionId);
+    await this.crossFormIdBySessionCache.set(key, { formId }, this.ttl); // Set the form id in cache with a TTL of 24 hours
+  }
+  async saveInformationToAllowCrossFormResume(
+    request: HapiRequest,
+    transferId: string
+  ) {
+    /* Cross Form Redirect Session Resume Step 2: Save additional information when sending out the cross form
+      In order to be able to re-populate the state after cross form has been clicked without relying on browser state we save the current:
+      - session id (as a new session will be started when opening in a differnt browser)
+      - form id (i.e "ReportAnOutbreak", to know which cache key to retrieve state from)
+    */
+    const sessionId = request.yar.id;
+    const crossFormFormId = request.params.id as string;
+
+    if (!sessionId || !crossFormFormId) {
+      request.logger.error("Cross Form Redirect: Missing data in step 2", {
+        sessionId,
+        crossFormFormId,
+      });
+
+      return;
+    }
+
+    /* Retrieve form id using the FormIdBySessionIdLookup */
+    const previousFormEntry = await this.crossFormIdBySessionCache.get(
+      getFormIdBySessionIdKey(sessionId)
+    );
+
+    if (!previousFormEntry) {
+      request.logger.error("Cross Form Redirect: Missing data in step 2", {
+        sessionId,
+        crossFormFormId,
+        previousFormEntry,
+      });
+
+      return;
+    }
+
+    /* Save information required to populate state from previous session */
+    await this.crossFormReturnDataByTransferId.set(
+      getReturnDataByTransferId(transferId),
+      {
+        sessionId,
+        formId: previousFormEntry.formId,
+      },
+      this.ttl
+    );
+
+    // Clean up the temporary form id by session id entry
+    await this.crossFormIdBySessionCache.drop(
+      getFormIdBySessionIdKey(sessionId)
+    );
+  }
+}
+
+type TypedCache<T> = Policy<T, PolicyOptions<T>>;
+type FormIdBySessionIdRecord = { formId: string };
+const getFormIdBySessionIdKey = (sessionId: string) => {
+  return `cross_form_id_by_session:${sessionId.toLocaleLowerCase()}`;
+};
+type CrossFormReturnDataByTransferId = { sessionId: string; formId: string };
+const getReturnDataByTransferId = (transferId: string) => {
+  return `cross_form_return_data_by_transfer_id:${transferId.toLocaleLowerCase()}`;
+};

--- a/runner/src/server/services/index.ts
+++ b/runner/src/server/services/index.ts
@@ -10,6 +10,7 @@ export { AddressService } from "./addressService";
 export { ExitService } from "./ExitService";
 export { FormSecurityService } from "./formSecurityService";
 export { MsalAuthorizer } from "./msalAuthorizerService";
+export { CrossFormCacheService } from "./CrossFormCacheService";
 export {
   SecureFormSubmissionService,
   getSecureFormSubmissionServiceInstance,

--- a/runner/src/server/types.ts
+++ b/runner/src/server/types.ts
@@ -20,6 +20,7 @@ import {
   StatusService,
   UploadService,
   WebhookService,
+  CrossFormCacheService,
 } from "./services";
 import { QueueStatusService } from "server/services/queueStatusService";
 import { QueueService } from "./services/QueueService";
@@ -29,6 +30,7 @@ type Services = (
   services: string[]
 ) => {
   cacheService: CacheService;
+  crossFormCacheService: CrossFormCacheService; // Add the crossFormCacheService here
   magicLinkCacheService: MagicLinkCacheService;
   notifyService: NotifyService;
   payService: PayService;


### PR DESCRIPTION
> [!NOTE]
> This template is designed to help both contributors and maintainers. It is a checklist to ensure all necessary
> information is provided, and prompts contributors on any contribution guidelines they have missed.
>
> Do not remove sections.
> They are important for the review process and help maintainers ensure quality and good documentation across the
> project.
>
> Some checkboxes will not apply to every change, so feel free to leave them unchecked if they are not relevant.

# Description

Proof of concept to investigate whether form state can be transferred between forms/services using Redis rather than relying on browser session continuity.

The implementation is based on the existing Magic Link resume pattern, but removes all email-specific functionality (HMAC, JWT, Notify, retry cookies, email validation etc.) and focuses purely on the cache/state handoff.

## Context

This PR is for collaboration purposes only.

<!--
Include these details if applicable:
- A summary of the change
- A link to the issue this change addresses
- Motivation and context for the change
- Acceptance criteria if you have any
- A screen recording or screenshots of the feature or change
-->

## Changes

### New Controllers

- `CrossFormRedirectController`
    
    - Handles transition from Form 1 to Form 2.
    - Saves Form 1 information before redirecting.
- `CrossFormSubmitController`
    
    - Added processing step similar to Magic Link `/submit1`.
    - Generates transferId.
    - Creates transfer lookup entry.
    - Redirects to return route.
- `CrossFormReturnController`
    
    - Added restore processing step.
    - Loads transfer lookup.
    - Intended to restore previous form state.
    - Added extensive logging around session IDs and cache state.

### New Service

- `CrossFormCacheService`

Added methods:

- `saveFormIdBeforeCrossFormRedirectToAllowResume()`
- `saveInformationToAllowCrossFormResume()`
- `restoreInformationFromCrossFormResume()`
- `mergeFormStateFromPreviousSession()`
- `getFormState()`
- `mergeFormState()`
- `clearFormState()`

### Form Configuration

- Added submit-processing page pattern similar to Magic Link.
- Added return page/controller.
- Fixed invalid JSON controller configuration (`controller` vs `controllers`).

### Logging

Added logging for:

- Session IDs
- Transfer IDs
- Cache keys
- Cache retrievals
- Restored form states

## Type of change

What is the type of change you are making?

- [ ] Chore or documentation (non-breaking change that does not add functionality)
- [ ] ADR (Architectural Decision Record, non-breaking change that documents or proposes a decision)
- [ ] Refactor (non-breaking change that improves code quality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### PR title

PR titles should be prefixed with the type of change you are making, based on the [README.md#versioning](https://github.com/XGovFormBuilder/digital-form-builder?tab=readme-ov-file#versioning).
This is so that when performing a squash merge, the PR title is automatically used as the commit message.

Have you updated the PR title to match the type of change you are making?

- [ ] Yes
- [ ] No, I need help or guidance

# Testing

<!--
Several departments use XGovFormBuilder in production.
Automated tests help ensure that changes do not break existing functionality for another department.

Maintainers are sympathetic to the time constraints of government departments, but please try to be good citizens and add tests when possible.
-->

## Automated tests

Have you added automated tests?

- [ ] Yes, unit or integration tests
- [ ] Yes, end-to-end (cypress) tests
- [ ] No, tests are not required for this change
- [ ] No, I need help or guidance
- [ ] No (explain why tests are not required or can't be added at this time)

## Manual tests

Have you manually tested your changes?

- [ ] Yes
- [ ] No, manual tests are not required or sufficiently covered by automated tests

Have you attached an example form JSON or snippet for the reviewer in this PR?

- [ ] Yes
- [ ] No, any existing form can be used
- [ ] No, it is not required or not applicable

### Steps to test

<!--
Only fill out this section if you answered "Yes" to manually testing your changes.

In this section
- describe the tests that you ran to verify your changes
- provide instructions and a form JSON or snippet so we can reproduce the test if necessary

If uploading a form JSON, use the "attach files" feature in GitHub PR.
-->

1. Step 1
2. Step 2

# Documentation

Have you updated the documentation?

- [ ] Yes, I have updated [./docs](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs) for this change since additional explanation or steps to use/configure the feature is required
- [ ] Yes, I have added or updated an [ADR](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs/adr) for this change since it is large, complex, or has significant architectural implications
- [ ] Yes, I have added inline comments for hard-to-understand areas
- [ ] No, I am not sure if documentation is required
- [ ] No, documentation is not required for this change

# Discussion

> [!WARNING]
>
> Large or complex changes may require discussion with the maintainers before they can be merged. If it has not yet been discussed, it may delay the review process

Have you discussed this change with the maintainers?

- [ ] Yes, I have discussed this change with the maintainers on slack, email or via GitHub issues
- [ ] Yes, this change is an ADR to help kick-off discussion
- [ ] No, this change is small and does not require discussion
- [ ] No, I am not sure if one is required
