### PR TITLE
patch: Add support for apostrophes in emails

### DIFF
--- a/runner/package.json
+++ b/runner/package.json
@@ -19,6 +19,7 @@
     "test-cov": "yarn run unit-test-cov",
     "test:dev": "lab -T test/.transform.js -P (test|src)/**/*.test.* -v test --coverage-exclude",
     "unit-test": "lab -T test/.transform.js -P (test|src)/**/*.test.* -v test -S -v -r console -o stdout -r html -o unit-test.html -I version -l",
+    "unit-test-pattern": "lab -T test/.transform.js -g 'Email' -v test",
     "unit-test-cov": "lab -T test/.transform.js -P (test|src)/**/*.test.* -v test -t 83 -S -v -r console -o stdout -r lcov -o test-coverage/lab/lcov.info -r html -o test-coverage/lab/unit-test.html -r junit -o test-results/junit/unit-test.xml -I version -l",
     "a11y": "node test/audit/components && node lighthouse",
     "symlink-env": "./bin/symlink-config",

--- a/runner/src/server/plugins/engine/components/EmailAddressField.ts
+++ b/runner/src/server/plugins/engine/components/EmailAddressField.ts
@@ -6,7 +6,8 @@ import { FormComponent } from "./FormComponent";
 import { addClassOptionIfNone } from "./helpers";
 import joi, { Schema } from "joi";
 
-const EMAIL_REGEX = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
+// For reference, see https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
+export const EMAIL_REGEX = /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
 
 export class EmailAddressField extends FormComponent {
   formSchema;

--- a/runner/test/cases/server/plugins/engine/EmailAddressField.test.ts
+++ b/runner/test/cases/server/plugins/engine/EmailAddressField.test.ts
@@ -1,6 +1,9 @@
 import * as Code from "@hapi/code";
 import * as Lab from "@hapi/lab";
-import { EmailAddressField } from "src/server/plugins/engine/components";
+import {
+  EmailAddressField,
+  EMAIL_REGEX,
+} from "src/server/plugins/engine/components/EmailAddressField";
 
 const lab = Lab.script();
 exports.lab = lab;
@@ -16,9 +19,53 @@ suite("Email address field", () => {
       options: {},
       schema: {},
     };
+
     const emailAddressField = new EmailAddressField(def, {});
     expect(emailAddressField.getViewModel({})).to.contain({
       autocomplete: "email",
     });
+  });
+
+  test("Should accept valid emails", () => {
+    const validEmails = [
+      "o'brien@example.com",
+      "mary.o'connor@example.co.uk",
+      "d'angelo123@sub.domain.org",
+      "test.email+alex@leetcode.com",
+      "user_name@example-domain.com",
+      "x@example.io",
+      "user@domain",
+      "..abc@outlook.com",
+    ];
+
+    const regex = new RegExp(EMAIL_REGEX);
+
+    let checkedValidEmails = 0;
+    validEmails.forEach((email) => {
+      checkedValidEmails++;
+      expect(regex.test(email), email).to.be.true();
+    });
+    expect(checkedValidEmails).to.equal(validEmails.length);
+  });
+
+  test("Should reject invalid emails", () => {
+    const invalidEmails = [
+      "plainaddress",
+      "@missinglocal.com",
+      "missingatsign.com",
+      "user@.com",
+      "user@domain..com",
+      "user@-domain.com",
+      "user@do'main.com",
+    ];
+
+    const regex = new RegExp(EMAIL_REGEX);
+
+    let checkedInvalidEmails = 0;
+    invalidEmails.forEach((email) => {
+      checkedInvalidEmails++;
+      expect(regex.test(email), email).to.be.false();
+    });
+    expect(checkedInvalidEmails).to.equal(invalidEmails.length);
   });
 });


### PR DESCRIPTION
# Description

## Context

<img width="1940" height="1810" alt="before_apostrophy_fix" src="https://github.com/user-attachments/assets/ccd0feff-290a-4d7a-acba-60e62d02882b" />

<img width="1784" height="1506" alt="after_apostrophy_fix" src="https://github.com/user-attachments/assets/ef15bffa-bc52-4a80-acdd-fbcc8b00a5ff" />

## Changes

- Correct the email regex
- Add unit test to verify email regex

## Type of change

What is the type of change you are making?

- [ ] Chore or documentation (non-breaking change that does not add functionality)
- [ ] ADR (Architectural Decision Record, non-breaking change that documents or proposes a decision)
- [ ] Refactor (non-breaking change that improves code quality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### PR title

PR titles should be prefixed with the type of change you are making, based on the [README.md#versioning](https://github.com/XGovFormBuilder/digital-form-builder?tab=readme-ov-file#versioning).
This is so that when performing a squash merge, the PR title is automatically used as the commit message.

Have you updated the PR title to match the type of change you are making?

- [X] Yes
- [ ] No, I need help or guidance

# Testing

## Automated tests

Have you added automated tests?

- [X] Yes, unit or integration tests
- [ ] Yes, end-to-end (cypress) tests
- [ ] No, tests are not required for this change
- [ ] No, I need help or guidance
- [ ] No (explain why tests are not required or can't be added at this time)

## Manual tests

Have you manually tested your changes?

- [X] Yes
- [ ] No, manual tests are not required or sufficiently covered by automated tests

Have you attached an example form JSON or snippet for the reviewer in this PR?

- [ ] Yes
- [X] No, any existing form can be used (**kls-enquiries**)
- [ ] No, it is not required or not applicable

### Steps to test

1. Open the kls-enquiries form
2. Continue on to magic link step
3. Enter an email with an apostrophe in the first part (left of the @)

# Documentation

Have you updated the documentation?

- [ ] Yes, I have updated [./docs](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs) for this change since additional explanation or steps to use/configure the feature is required
- [ ] Yes, I have added or updated an [ADR](https://github.com/XGovFormBuilder/digital-form-builder/tree/main/docs/adr) for this change since it is large, complex, or has significant architectural implications
- [ ] Yes, I have added inline comments for hard-to-understand areas
- [ ] No, I am not sure if documentation is required
- [X] No, documentation is not required for this change

# Discussion

Have you discussed this change with the maintainers?

- [ ] Yes, I have discussed this change with the maintainers on slack, email or via GitHub issues
- [ ] Yes, this change is an ADR to help kick-off discussion
- [X] No, this change is small and does not require discussion
- [ ] No, I am not sure if one is required
